### PR TITLE
Drop redundant implementation from @typing.overload functions

### DIFF
--- a/result/result.py
+++ b/result/result.py
@@ -11,15 +11,16 @@ class Ok(Generic[T]):
     A value that indicates success and which stores arbitrary data for the return value.
     """
 
+    _value: T
     __match_args__ = ("value",)
 
     @overload
     def __init__(self) -> None:
-        pass
+        ...
 
     @overload
     def __init__(self, value: T) -> None:
-        self._value = value
+        ...
 
     def __init__(self, value: Any = True) -> None:
         self._value = value


### PR DESCRIPTION
typing overloads are for the type checker only and their implementation
is supposed to be empty, literally using ... as the function body. see
https://docs.python.org/3/library/typing.html#typing.overload