### PR TITLE
Define __slots__ to save memory on Ok and Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Possible log types:
 - `[removed]` Drop support for Python 3.5 (#34)
 - `[added]` Add support for Python 3.9 and 3.10 (#50)
 - `[changed]` Make the `Ok` type covariant in regard to its wrapped type `T`.
-  Likewise for `Err` in regard to `E`. This should result in more intuitive 
-  type checking behaviour. For instance, `Err[TypeError]` will get recognized 
-  as a subtype of `Err[Exception]` by type checkers. See [PEP 438] for a 
+  Likewise for `Err` in regard to `E`. This should result in more intuitive
+  type checking behaviour. For instance, `Err[TypeError]` will get recognized
+  as a subtype of `Err[Exception]` by type checkers. See [PEP 438] for a
   detailed explanation of covariance and its implications.
+- `[changed]` `Ok` and `Err` now define `__slots__` to save memory (#55, #58)
 
 [PEP 438]: https://www.python.org/dev/peps/pep-0483/#covariance-and-contravariance
 

--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,10 @@ Values and errors can be mapped using ``map``, ``map_or``, ``map_or_else`` and
    >>> Err(1).map_err(lambda x: x + 1)
    Err(2)
 
+To save memory, both the ``Ok`` and ``Err`` classes are ‘slotted’,
+i.e. they define ``__slots__``. This means assigning arbitrary
+attributes to instances will raise ``AttributeError``.
+
 
 FAQ
 -------

--- a/result/result.py
+++ b/result/result.py
@@ -12,6 +12,7 @@ class Ok(Generic[T]):
     """
 
     __match_args__ = ("value",)
+    __slots__ = ("_value",)
 
     @overload
     def __init__(self) -> None:
@@ -129,6 +130,7 @@ class Err(Generic[E]):
     """
 
     __match_args__ = ("value",)
+    __slots__ = ("_value",)
 
     def __init__(self, value: E) -> None:
         self._value = value

--- a/result/tests.py
+++ b/result/tests.py
@@ -169,3 +169,15 @@ def test_error_context():
     with pytest.raises(UnwrapError) as e:
         n.unwrap()
     assert e.value.result is n
+
+
+def test_slots() -> None:
+    """
+    Ok and Err have slots, so assigning arbitrary attributes fails.
+    """
+    o = Ok('yay')
+    n = Err('nay')
+    with pytest.raises(AttributeError):
+        o.some_arbitrary_attribute = 1  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        n.some_arbitrary_attribute = 1  # type: ignore[attr-defined]


### PR DESCRIPTION
Using `__slots__` saves a dict creation for each instance, reducing memory
footprint. This can become especially relevant when collecting many
Result instances.

Note that `UnwrapError` does not get the same treatment: it is pointless
since would only work if the complete inheritance hierarchy has slots,
but the built-in Exception class does not define slots.

fixes #55.