### PR TITLE
Modernize flake8 config: remove old config and add line length config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ addopts = --flake8 --tb=short --cov=.
 python_files = tests.py
 norecursedirs = *.egg tmp* build .tox
 flake8-ignore =
-    *.py E126 E127 E128 W504 F811  # Note: Remove F811 after the next flake8 upgrade
+    *.py E126 E127 E128 W504
     setup.py ALL
     */tests/* ALL
     */docs/* ALL
@@ -15,3 +15,6 @@ flake8-ignore =
     */TOXENV/* ALL
     result/tests-pattern-matching.py ALL  # Note: Looks like pytest-flake8 doesn't support 3.10 yet
 flake8-max-line-length = 99
+
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
Add a plain flake8 config (applicable when not run via pytest, e.g.
directly in editor) and remove the apparently no longer needed F811
ignore.