### PR TITLE
Migrate to a modern (mostly) declarative setuptools config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python }}-
       - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install --requirement requirements-dev.txt
 
       # Install library
       - name: Install result
-        run: pip install -e .
+        run: pip install --editable .
 
       # Tests
       - name: Run tests
@@ -51,6 +51,12 @@ jobs:
         if: matrix.python == '3.10'
       - name: Run mypy on result.py
         run: mypy result/result.py
+
+      # Packaging
+      - name: Build packages
+        run: |
+          pip install --upgrade build pip setuptools wheel
+          python -m build
 
       # Coverage
       - name: Upload coverage to codecov.io

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,7 @@ Do a signed commit and signed tag of the release:
 
 Build source and binary distributions:
 
-    python3 setup.py sdist
-    python3 setup.py bdist_wheel
+    python3 -m build
 
 Sign files:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/result/__init__.py
+++ b/result/__init__.py
@@ -1,2 +1,10 @@
-from .result import Result, Ok, Err, UnwrapError, OkErr
-__all__ = ['Result', 'Ok', 'Err', 'UnwrapError', 'OkErr']
+from .result import Err, Ok, OkErr, Result, UnwrapError
+
+__all__ = [
+    "Err",
+    "Ok",
+    "OkErr",
+    "Result",
+    "UnwrapError",
+]
+__version__ = "0.7.0.dev"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,35 @@
 [metadata]
+name = result
+version = attr: result.__version__
+description = A Rust-like result type for Python
+long_description = file: README.rst
+keywords = rust, result, enum
+author = Danilo Bargen
+author_email = mail@dbrgn.ch
+maintainer = rustedpy github org members (https://github.com/rustedpy)
+url = https://github.com/rustedpy/result
+license = MIT
 license_file = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
+
+[options]
+include = result
+include_package_data = True
+packages = find:
+python_requires = >=3.6
+zip_safe = True
+
+[options.package_data]
+result = py.typed
 
 [tool:pytest]
 addopts = --flake8 --tb=short --cov=.

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,3 @@
 from setuptools import setup
 
-readme = open('README.rst').read()
-
-setup(name='result',
-      version='0.7.0-dev',
-      description='A rust-like result type for Python',
-      author='Danilo Bargen',
-      author_email='mail@dbrgn.ch',
-      url='https://github.com/rustedpy/result',
-      packages=['result'],
-      package_data={'result': ['py.typed']},
-      zip_safe=True,
-      include_package_data=True,
-      license='MIT',
-      keywords='rust result enum',
-      long_description=readme,
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
-          'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3 :: Only',
-      ])
+setup()


### PR DESCRIPTION
This migrates the packaging infra to a modern mostly declarative
setuptools configuration, almost literally following the best practices
layed out in the setuptools documentation; see https://setuptools.pypa.io/

The version info has moved to a ‘result.__version__’ attribute (in the
‘__init__.py’ file), which is a common pattern in many packages, and
setuptools reads it from there (single source of truth). Run black+isort
on the file while at it.

The new packages can be built the modern way using the PEP517 compliant
‘build’ tool via ‘python -m build’ after a ‘pip install build’. Reflect
this in RELEASING.md. The remaining setup.py file is almost empty, but
it is not removed because it is still needed for --editable development
installs. See setuptools docs and this article for details:
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Also added a packaging build step to the CI to ensure packaging keeps working.
