### PR TITLE
Make mypy run as --strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,25 @@ files = [
 # Exclude files with pattern matching syntax until Mypy supports it;
 # see https://github.com/python/mypy/issues/10201
 exclude = "tests/test_pattern_matching.py"
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 no_implicit_optional = true
+no_implicit_reexport = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
 show_none_errors = true
+strict_equality = true
 strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
+warn_unused_configs = true
 warn_unused_ignores = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
To keep this library ‘mypy strict’, change the Mypy config to the
equivalent of --strict on the command line. (Config values were copied
from ‘mypy --help’ output into the config file.)

depends on these pull requests:

- [x] #65 
- [x] #67