### PR TITLE
Add decorator to turn regular functions in Result returning ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Possible log types:
 
 ## [Unreleased]
 
+- `[added]` `as_result` decorator to turn regular functions into
+  `Result` returning ones (#33, 71)
 - `[removed]` Drop support for Python 3.6 (#49)
 - `[added]` Implement `unwrap_or_else` (#74)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
 
 [options]
 include_package_data = True
+install_requires =
+    typing_extensions;python_version<'3.10'
 package_dir =
     =src
 packages = find:

--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -1,4 +1,4 @@
-from .result import Err, Ok, OkErr, Result, UnwrapError
+from .result import Err, Ok, OkErr, Result, UnwrapError, as_result
 
 __all__ = [
     "Err",
@@ -6,5 +6,6 @@ __all__ = [
     "OkErr",
     "Result",
     "UnwrapError",
+    "as_result",
 ]
 __version__ = "0.7.0"


### PR DESCRIPTION
Add decorator to turn regular functions in Result returning ones

Add a as_result() helper to make a decorator to turn a function into one
that returns a Result: Regular return values are turned into
Ok(return_value). Raised exceptions of the specified exception type(s)
are turned into Err(exc).

The decorator is signature-preserving, except for wrapping the return
type into a Result, of course.

For type annotations, this depends on typing.ParamSpec which requires
Python 3.10+ (or use typing_extensions); see
PEP612 (https://www.python.org/dev/peps/pep-0612/).

Fixes #33.