### PR TITLE
Adapt a few tests to reach 100% code coverage in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ warn_unused_ignores = true
 addopts = [
   "--flake8",
   "--tb=short",
-  "--cov=.",
+  "--cov=result",
+  "--cov=tests",
   "--cov-report=term",
   "--cov-report=xml",
 ]

--- a/result/result.py
+++ b/result/result.py
@@ -17,11 +17,11 @@ class Ok(Generic[T]):
 
     @overload
     def __init__(self) -> None:
-        ...
+        ...  # pragma: no cover
 
     @overload
     def __init__(self, value: T) -> None:
-        ...
+        ...  # pragma: no cover
 
     def __init__(self, value: Any = True) -> None:
         self._value = value

--- a/tests/test_pattern_matching.py
+++ b/tests/test_pattern_matching.py
@@ -2,22 +2,26 @@ from result import Err, Ok, Result
 
 
 def test_pattern_matching_on_ok_type() -> None:
-    o: Result[str, int] = Ok('yay')
+    """
+    Pattern matching on ``Ok()`` matches the contained value.
+    """
+    o: Result[str, int] = Ok("yay")
     match o:
-        case Ok(f):
-            f  # Avoids flake8 F841 unused variable
-            assert True
-        case Err(e):
-            e
-            assert False
+        case Ok(value):
+            reached = True
+
+    assert value == "yay"
+    assert reached
 
 
 def test_pattern_matching_on_err_type() -> None:
-    n: Result[int, str] = Err('nay')
+    """
+    Pattern matching on ``Err()`` matches the contained value.
+    """
+    n: Result[int, str] = Err("nay")
     match n:
-        case Ok(f):
-            f
-            assert False
-        case Err(e):
-            e
-            assert True
+        case Err(value):
+            reached = True
+
+    assert value == "nay"
+    assert reached

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -33,8 +33,17 @@ def test_hash() -> None:
 
 
 def test_repr() -> None:
-    assert Ok(u"£10") == eval(repr(Ok(u"£10")))
-    assert Ok("£10") == eval(repr(Ok("£10")))
+    """
+    ``repr()`` returns valid code if the wrapped value's ``repr()`` does as well.
+    """
+    o = Ok(123)
+    n = Err(-1)
+
+    assert repr(o) == "Ok(123)"
+    assert o == eval(repr(o))
+
+    assert repr(n) == "Err(-1)"
+    assert n == eval(repr(n))
 
 
 def test_ok() -> None:


### PR DESCRIPTION
Changes:

- Adapt test_repr(): assert on actual expected values, add docstring,
  drop obsolete u'foo' python 2 syntax

- Adapt pattern matching tests to not have any dead code; add docstring

- Add coverage excludes for typing.overloads() function bodies that are
  never executed

- Tell pytest --cov to cover the result/ and tests/ dir, not arbitrary
  Python code in the root dir (such as setup.py)

The result is 100% test coverage: 🎉

    Name                             Stmts   Miss  Cover
    ----------------------------------------------------
    result/__init__.py                   3      0   100%
    result/result.py                   106      0   100%
    tests/test_pattern_matching.py      15      0   100%
    tests/test_result.py               134      0   100%
    ----------------------------------------------------
    TOTAL                              258      0   100%