### PR TITLE
Implement Ok.unwrap_or_else and Err.unwrap_or_else

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ A custom error message can be displayed instead by using ``expect`` and ``expect
     >>> res2.expect_err('not err')
     'nay'
 
-A default value can be returned instead by using ``unwrap_or``:
+A default value can be returned instead by using ``unwrap_or`` or ``unwrap_or_else``:
 
 .. sourcecode:: python
 
@@ -230,6 +230,10 @@ A default value can be returned instead by using ``unwrap_or``:
     'yay'
     >>> res2.unwrap_or('default')
     'default'
+    >>> res1.unwrap_or_else(str.upper)
+    'yay'
+    >>> res2.unwrap_or_else(str.upper)
+    'NAY'
 
 Values and errors can be mapped using ``map``, ``map_or``, ``map_or_else`` and
 ``map_err``:

--- a/result/result.py
+++ b/result/result.py
@@ -211,8 +211,8 @@ class Err(Generic[E]):
 
     def unwrap_or_else(self, op: Callable[[E], T]) -> T:
         """
-        The contained result is `Ok`, so return original value mapped to
-        a new value using the passed in `op` function.
+        The contained result is ``Err``, so return the result of applying
+        ``op`` to the error value.
         """
         return op(self._value)
 

--- a/result/result.py
+++ b/result/result.py
@@ -94,7 +94,9 @@ class Ok(Generic[T]):
         return self._value
 
     def unwrap_or_else(self, op: Callable[[E], T]) -> T:
-        """Returns the value."""
+        """
+        Return the value.
+        """
         return self._value
 
     def map(self, op: Callable[[T], U]) -> 'Result[U, E]':

--- a/result/result.py
+++ b/result/result.py
@@ -93,6 +93,10 @@ class Ok(Generic[T]):
         """
         return self._value
 
+    def unwrap_or_else(self, op: Callable[[E], T]) -> T:
+        """Returns the value."""
+        return self._value
+
     def map(self, op: Callable[[T], U]) -> 'Result[U, E]':
         """
         The contained result is `Ok`, so return `Ok` with original value mapped to
@@ -202,6 +206,13 @@ class Err(Generic[E]):
         Return `default`.
         """
         return default
+
+    def unwrap_or_else(self, op: Callable[[E], T]) -> T:
+        """
+        The contained result is `Ok`, so return original value mapped to
+        a new value using the passed in `op` function.
+        """
+        return op(self._value)
 
     def map(self, op: Callable[[T], U]) -> 'Result[U, E]':
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -119,6 +119,13 @@ def test_unwrap_or() -> None:
     assert n.unwrap_or('another_default') == 'another_default'
 
 
+def test_unwrap_or_else() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    assert o.unwrap_or_else(str.upper) == 'yay'
+    assert n.unwrap_or_else(str.upper) == 'NAY'
+
+
 def test_map() -> None:
     o = Ok('yay')
     n = Err('nay')


### PR DESCRIPTION
See #74 . `Result[T, E].unwrap_or_else(func_E_to_T)` always returns a "T"/OK type by forcing E -> T "the error back to the ok type" with a function/callback. 