### PR TITLE
Add a `.value_safe()` method (name is not great, open to suggestions 😆 )

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -86,6 +86,12 @@ class Ok(Generic[T]):
         Return the inner value.
         """
         return self._value
+    
+    def value_safe(self) -> T:
+        """
+        Return the inner value, method only exists on Ok types.
+        """
+        return self._value
 
     def expect(self, _message: str) -> T:
         """

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
+from warnings import warn
 from typing import (
+    Annotated,
     Any,
     Callable,
     Generic,
@@ -28,6 +30,9 @@ F = TypeVar("F")
 P = ParamSpec("P")
 R = TypeVar("R")
 TBE = TypeVar("TBE", bound=BaseException)
+
+# https://github.com/python/typing/issues/609#issuecomment-503952387
+DeprecatedE = Annotated[E, "deprecated"]
 
 
 class Ok(Generic[T]):
@@ -84,12 +89,6 @@ class Ok(Generic[T]):
     def value(self) -> T:
         """
         Return the inner value.
-        """
-        return self._value
-    
-    def value_safe(self) -> T:
-        """
-        Return the inner value, method only exists on Ok types.
         """
         return self._value
 
@@ -216,9 +215,22 @@ class Err(Generic[E]):
         return self._value
 
     @property
-    def value(self) -> E:
+    def value(self) -> DeprecatedE:
         """
+        @deprecated
         Return the inner value.
+        """
+        warn(
+            "Accessing `.value` on an Err type is deprecated, please use `.err_value`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value
+
+    @property
+    def err_value(self) -> E:
+        """
+        Return the error value.
         """
         return self._value
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -11,7 +11,6 @@ def test_ok_factories() -> None:
     instance = Ok(1)
     assert instance._value == 1
     assert instance.is_ok() is True
-    assert instance.value_safe() == 1
 
 
 def test_err_factories() -> None:
@@ -63,8 +62,6 @@ def test_err() -> None:
     assert res.is_ok() is False
     assert res.is_err() is True
     assert res.value == ':('
-    with pytest.raises(AttributeError):
-        assert res.value_safe()  # type: ignore
 
 
 def test_ok_method() -> None:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -11,6 +11,7 @@ def test_ok_factories() -> None:
     instance = Ok(1)
     assert instance._value == 1
     assert instance.is_ok() is True
+    assert instance.value_safe() == 1
 
 
 def test_err_factories() -> None:
@@ -62,6 +63,8 @@ def test_err() -> None:
     assert res.is_ok() is False
     assert res.is_err() is True
     assert res.value == ':('
+    with pytest.raises(AttributeError):
+        assert res.value_safe()  # type: ignore
 
 
 def test_ok_method() -> None:


### PR DESCRIPTION
I may be mistaken, but I haven't seen a method for accessing an Ok value that only exists on the `Ok` class. For instance using `Err.ok()` won't raise errors in pylance as it returns `None` which is falsy, but not a type-checking error unless it happens to be provided somewhere that won't accept `None`.

With a method (or we could use a property, not sure if thats better in this situation) for accessing `self._value` that only exists on `Ok()` classes, pyright/mypy can typecheck any access of value.