### PR TITLE
No longer pin development dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-build~=0.7.0
+build
 flake8
-twine~=3.6.0
-pytest==6.2.5
-pytest-cov>=2.8,<3
-mypy>=0.910
-pytest-mypy-plugins>=1.9.1
+twine
+pytest
+pytest-cov
+mypy
+pytest-mypy-plugins


### PR DESCRIPTION
Just use the latest available (and compatible) versions for local development and CI.

Without a proper upgrading process in place, which is overkill for a small project like this, we should just deal with fallout whenever it happens instead of slowly getting stuck in the past… and missing issues occurring with newer tools as they become available.

For example, an older pytest version (6.x) was used, while 7.x is out for a while already. Same for other tools like twine. Latest version as of 2022-09-16:

    $ pip freeze | grep --fixed-strings --file=requirements-dev.txt
    build==0.8.0
    flake8==5.0.4
    mypy==0.971
    mypy-extensions==0.4.3
    pytest==7.1.3
    pytest-cov==3.0.0
    pytest-mypy-plugins==1.10.0
    twine==4.0.1