### PR TITLE
Change unrelease version to "0.9.0.dev0"

### DIFF
--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -8,4 +8,4 @@ __all__ = [
     "UnwrapError",
     "as_result",
 ]
-__version__ = "0.0.0"
+__version__ = "0.9.0.dev0"

--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -8,4 +8,4 @@ __all__ = [
     "UnwrapError",
     "as_result",
 ]
-__version__ = "0.8.0"
+__version__ = "0.0.0"


### PR DESCRIPTION
I noticed while doing,
```
pip install git+https://github.com/rustedpy/result
```
The unreleased master branch version is reported as `0.8.0`, which is wrong. We can set to to `0.0.0` until we need to make a release so people aren't confused if they're installing the master branch version