### PR TITLE
Type annotation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Possible log types:
 
 - `[added]` Implement `unwrap_or_raise` (#95)
 - `[added]` Add support for Python 3.11 (#107)
+- `[changed]` Narrowing of return types on methods of `Err` and `Ok`. (#106)
+- `[fixed]` Fix failing type inference for `Result.map` and similar method
+  unions (#106)
 
 ## [0.8.0] - 2022-04-17
 

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -39,7 +39,7 @@
     res5 = res4.and_then(add1)
     reveal_type(res5) # N: Revealed type is "Union[result.result.Ok[builtins.int], result.result.Err[builtins.str]]"
     res6 = res4.or_else(toint)
-    reveal_type(res6) # N: Revealed type is "Union[result.result.Ok[builtins.int], result.result.Err[builtins.str]]"
+    reveal_type(res6) # N: Revealed type is "result.result.Ok[builtins.int]"
 
 - case: covariance
   disable_cache: false
@@ -57,3 +57,29 @@
     result_int_type: Result[int, TypeError] = ok_int or err_type
     result_float_exc: Result[float, Exception] = result_int_type
     result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Union[Ok[float], Err[Exception]]", variable has type "Union[Ok[int], Err[TypeError]]")  [assignment]
+
+- case: map_ok_err
+  disable_cache: false
+  main: |
+    from result import Err, Ok
+
+    o = Ok("42")
+    reveal_type(o.map(int))  # N: Revealed type is "result.result.Ok[builtins.int]"
+    reveal_type(o.map_err(int))  # N: Revealed type is "result.result.Ok[builtins.str]"
+
+    e = Err("42")
+    reveal_type(e.map(int))  # N: Revealed type is "result.result.Err[builtins.str]"
+    reveal_type(e.map_err(int))  # N: Revealed type is "result.result.Err[builtins.int]"
+
+- case: map_result
+  disable_cache: false
+  main: |
+    from result import Result, Ok
+
+    greeting_res: Result[str, ValueError] = Ok("Hello")
+
+    personalized_greeting_res = greeting_res.map(lambda g: f"{g}, John")
+    reveal_type(personalized_greeting_res) # N: Revealed type is "Union[result.result.Ok[builtins.str], result.result.Err[builtins.ValueError]]"
+
+    personalized_greeting = personalized_greeting_res.ok()
+    reveal_type(personalized_greeting) # N: Revealed type is "Union[builtins.str, None]"


### PR DESCRIPTION
This PR addresses a number of type inference related issues I've encountered with the result library.

Issue 1: Return types of methods are overly broad.
This leads to having to do casting or other trickery when you are working with an object that is known to be either `Ok` or `Err`, which is usually the case after having done an `isinstance` check. This PR narrows return types as much as possible, resolving this issue. The improvement is illustrated by an added test: `map_ok_err`.

Issue 2: Method parameter types reference type variables that cannot be inferred.
This leads to problems with type inference when calling methods on objects that are merely bounded to the `Result` union type. This PR addresses this by broadening types for unused method arguments to `object`. As a result, methods on the `Result` union type now type-checks properly. The PR adds a new test case, `map_result`, in order to demonstrate this.