### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         python:
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -47,7 +48,7 @@ jobs:
       - name: Run tests
         run: pytest --ignore=tests/test_pattern_matching.py
       - name: Run tests (pattern matching)
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.10' || matrix.python == '3.11'
         run: pytest tests/test_pattern_matching.py
 
       # Linters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ## [Unreleased]
 
 - `[added]` Implement `unwrap_or_raise` (#95)
+- `[added]` Add support for Python 3.11
 
 ## [0.8.0] - 2022-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Possible log types:
 ## [Unreleased]
 
 - `[added]` Implement `unwrap_or_raise` (#95)
-- `[added]` Add support for Python 3.11
+- `[added]` Add support for Python 3.11 (#107)
 
 ## [0.8.0] - 2022-04-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 files = [
   "src",
   "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ no_implicit_reexport = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-show_none_errors = true
 strict_equality = true
 strict_optional = true
 warn_redundant_casts = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    typing_extensions;python_version<'3.11'
+    typing_extensions;python_version<'3.10'
 package_dir =
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,13 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
 
 [options]
 include_package_data = True
 install_requires =
-    typing_extensions;python_version<'3.10'
+    typing_extensions;python_version<'3.11'
 package_dir =
     =src
 packages = find:

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -48,12 +48,12 @@
 
     ok_int: Ok[int] = Ok(42)
     ok_float: Ok[float] = ok_int
-    ok_int = ok_float  # E: Incompatible types in assignment (expression has type "Ok[float]", variable has type "Ok[int]")
+    ok_int = ok_float  # E: Incompatible types in assignment (expression has type "Ok[float]", variable has type "Ok[int]")  [assignment]
 
     err_type: Err[TypeError] = Err(TypeError("foo"))
     err_exc: Err[Exception] = err_type
-    err_type = err_exc  # E: Incompatible types in assignment (expression has type "Err[Exception]", variable has type "Err[TypeError]")
+    err_type = err_exc  # E: Incompatible types in assignment (expression has type "Err[Exception]", variable has type "Err[TypeError]")  [assignment]
 
     result_int_type: Result[int, TypeError] = ok_int or err_type
     result_float_exc: Result[float, Exception] = result_int_type
-    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Union[Ok[float], Err[Exception]]", variable has type "Union[Ok[int], Err[TypeError]]")
+    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Union[Ok[float], Err[Exception]]", variable has type "Union[Ok[int], Err[TypeError]]")  [assignment]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py39,py38,py37
+envlist = py311,py310,py39,py38,py37
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Now that Python 3.11 is released, it is time to start officially supporting it.