### PR TITLE
Fix build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 Result
 ======
 
-.. image:: https://img.shields.io/github/workflow/status/rustedpy/result/CI/master
+.. image:: https://img.shields.io/github/actions/workflow/status/rustedpy/result/ci.yml?branch=master
     :alt: GitHub Workflow Status (branch)
-    :target: https://github.com/rustedpy/result/actions?query=workflow%3ACI+branch%3Amaster
+    :target: https://github.com/rustedpy/result/actions/workflows/ci.yml?query=branch%3Amaster
 
 .. image:: https://codecov.io/gh/rustedpy/result/branch/master/graph/badge.svg
     :alt: Coverage


### PR DESCRIPTION
The build badge at the top of the README became unavailable/broken due to https://github.com/badges/shields/issues/8671.

I also changed the link target to a more direct, workflow file-based URL to show the CI workflows for the `master` branch.