### PR TITLE
Added bool truthyness to Ok, Err and UnwrapError objects

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -60,6 +60,9 @@ class Ok(Generic[T]):
 
     def __hash__(self) -> int:
         return hash((True, self._value))
+    
+    def __bool__(self) -> bool:
+        return True
 
     def is_ok(self) -> Literal[True]:
         return True
@@ -191,6 +194,9 @@ class Err(Generic[E]):
 
     def __hash__(self) -> int:
         return hash((False, self._value))
+
+    def __bool__(self) -> bool:
+        return False
 
     def is_ok(self) -> Literal[False]:
         return False
@@ -338,6 +344,9 @@ class UnwrapError(Exception):
         Returns the original result.
         """
         return self._result
+
+    def __bool__(self) -> bool:
+        return False
 
 
 def as_result(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -302,6 +302,21 @@ def test_as_result_type_checking() -> None:
     assert res.ok() == 123
 
 
+def test_bool() -> None:
+    """
+    Ensure that types coerce to bool correctly
+    """
+    num = Ok(3)
+    errnum = Err(2)
+
+    assert bool(num) == True
+    assert bool(errnum) == False
+
+    with pytest.raises(UnwrapError) as exc_info:
+        errnum.expect("failure")
+    assert bool(exc_info.value) == False
+
+
 def sq(i: int) -> Result[int, int]:
     return Ok(i * i)
 


### PR DESCRIPTION
Firstly, I love this library so thank you.
Recently we had a bug where we returned an `Err` and checked its truthyness in an if statement, while this is probably more our fault, it does seem like `Err` and `UnwrapError` probably shouldn't evaluable to `True` by default.

I have added tests as well.