### PR TITLE
Update result.py

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -14,7 +14,7 @@ from typing import (
     overload,
 )
 
-if sys.version_info[:2] >= (3, 10):
+if sys.version_info >= (3, 10):
     from typing import Final, Literal, ParamSpec, TypeAlias
 else:
     from typing_extensions import Final, Literal, ParamSpec, TypeAlias


### PR DESCRIPTION
https://github.com/rustedpy/result/issues/117

This change will fix PEP 484 compliance. See this discussion (https://github.com/microsoft/pylance-release/issues/4243#issuecomment-1509364152)