### PR TITLE
Add `.ok_value` and `.err_value`, deprecate `.value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+## Unreleased
+
+- `[deprecated]` `value` property to access the inner value (#37, #121)
+- `[added]` `ok_value` and `err_value` to access the inner value more safely (#37, #121)
+
 ## [0.10.0] - 2023-04-29
 
 - `[fixed]` Make python version check PEP 484 compliant (#118)

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
+from warnings import warn
 from typing import (
     Any,
     Awaitable,
@@ -82,6 +83,21 @@ class Ok(Generic[T]):
 
     @property
     def value(self) -> T:
+        """
+        Return the inner value.
+
+        @deprecated Use `ok_value` or `err_value` instead. This method will be
+        removed in a future version.
+        """
+        warn(
+            "Accessing `.value` on Result type is deprecated, please use `.ok_value` or '.err_value' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value
+
+    @property
+    def ok_value(self) -> T:
         """
         Return the inner value.
         """
@@ -213,6 +229,21 @@ class Err(Generic[E]):
 
     @property
     def value(self) -> E:
+        """
+        Return the inner value.
+
+        @deprecated Use `ok_value` or `err_value` instead. This method will be
+        removed in a future version.
+        """
+        warn(
+            "Accessing `.value` on Result type is deprecated, please use `.ok_value` or '.err_value' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value
+
+    @property
+    def err_value(self) -> E:
         """
         Return the inner value.
         """

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -90,7 +90,8 @@ class Ok(Generic[T]):
         removed in a future version.
         """
         warn(
-            "Accessing `.value` on Result type is deprecated, please use `.ok_value` or '.err_value' instead",
+            "Accessing `.value` on Result type is deprecated, please use " +
+            "`.ok_value` or '.err_value' instead",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -236,7 +237,8 @@ class Err(Generic[E]):
         removed in a future version.
         """
         warn(
-            "Accessing `.value` on Result type is deprecated, please use `.ok_value` or '.err_value' instead",
+            "Accessing `.value` on Result type is deprecated, please use " +
+            "`.ok_value` or '.err_value' instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -50,6 +50,16 @@ def test_repr() -> None:
     assert n == eval(repr(n))
 
 
+def test_ok_value() -> None:
+    res = Ok('haha')
+    assert res.ok_value == 'haha'
+
+
+def test_err_value() -> None:
+    res = Err('haha')
+    assert res.err_value == 'haha'
+
+
 def test_ok() -> None:
     res = Ok('haha')
     assert res.is_ok() is True


### PR DESCRIPTION
Closes #37

`.value` to be removed in a future version

TODO: Create a GitHub issue to not forget this for next release