### PR TITLE
fix: remove overloaded '__init__' methods on 'Ok'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+## Unreleased
+
+- `[changed]` `Ok` now requires an explicit value during instantiation
+
 ## [0.10.0] - 2023-04-29
 
 - `[fixed]` Make python version check PEP 484 compliant (#118)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Possible log types:
 
 ## Unreleased
 
-- `[changed]` `Ok` now requires an explicit value during instantiation
+- `[changed]` `Ok` now requires an explicit value during instantiation. Please
+  check out [MIGRATING.md], it will guide you through the necessary change in
+  your codebase.
 
 ## [0.10.0] - 2023-04-29
 
@@ -59,7 +61,6 @@ safe. Unfortunately this means some breaking changes. Please check out
 [MIGRATING.md], it will guide you through the necessary changes in your
 codebase.
 
-[MIGRATING.md]: https://github.com/rustedpy/result/blob/master/MIGRATING.md
 
 - [changed] Split result type into `Ok` and `Err` classes (#17, #27)
 - [deprecated] Python 3.4 support is deprecated and will be removed in the next
@@ -104,6 +105,7 @@ codebase.
 
  - Initial version
 
+[MIGRATING.md]: https://github.com/rustedpy/result/blob/master/MIGRATING.md
 [Unreleased]: https://github.com/rustedpy/result/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/rustedpy/result/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/rustedpy/result/compare/v0.8.0...v0.9.0

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,19 @@
 # Migration guides
 
+## 0.10 -> 0.11 migration
+
+The 0.11 migration includes one breaking change:
+
+`Ok` now requires an explicit value during instantiation. Previously, if no
+value was provides, a default value of `True` was implicitly used.
+
+To retain this behavior you can change any no-argument instantiations with:
+
+```diff
+- r = Ok()
++ r = Ok(True)
+```
+
 ## 0.5 -> 0.6 migration
 
 The 0.6 migration includes two breaking changes and some useful new functionality:

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -12,7 +12,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    overload,
 )
 
 if sys.version_info >= (3, 10):
@@ -39,15 +38,7 @@ class Ok(Generic[T]):
     __match_args__ = ("value",)
     __slots__ = ("_value",)
 
-    @overload
-    def __init__(self) -> None:
-        ...  # pragma: no cover
-
-    @overload
     def __init__(self, value: T) -> None:
-        ...  # pragma: no cover
-
-    def __init__(self, value: Any = True) -> None:
         self._value = value
 
     def __repr__(self) -> str:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
+import sys
 
 from typing import Callable
+if sys.version_info >= (3, 10):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 import pytest
 
@@ -79,7 +84,7 @@ def test_err_method() -> None:
 
 
 def test_no_arg_ok() -> None:
-    top_level: Result[None, None] = Ok()
+    top_level: Result[Literal[True], None] = Ok(True)
     assert top_level.is_ok() is True
     assert top_level.ok() is True
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
-import sys
 
 from typing import Callable
-if sys.version_info >= (3, 10):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import pytest
 
@@ -81,12 +76,6 @@ def test_err_method() -> None:
     n = Err('nay')
     assert o.err() is None  # type: ignore[func-returns-value]
     assert n.err() == 'nay'
-
-
-def test_no_arg_ok() -> None:
-    top_level: Result[Literal[True], None] = Ok(True)
-    assert top_level.is_ok() is True
-    assert top_level.ok() is True
 
 
 def test_expect() -> None:

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -26,8 +26,6 @@
         reveal_type(mapped_to_list) # N: Revealed type is "Union[builtins.list[builtins.int], None]"
 
     # Test constructor functions
-    res1 = Ok()
-    reveal_type(res1) # N: Revealed type is "result.result.Ok[builtins.str]"
     res2 = Ok(42)
     reveal_type(res2) # N: Revealed type is "result.result.Ok[builtins.int]"
     res3 = Err(1)


### PR DESCRIPTION
Closes #119

Force callers to specify an initial value.

`fp-ts` in the TypeScript world have an `Either` type, which requires explicit values, even if it's `undefined` or `null` (equivalent to Python's `None`). I think we can do the same here.