### PR TITLE
Fix type checking tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
+          # - '3.7'
     name: Python ${{ matrix.python }}
     steps:
       # Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.11'
           - '3.10'
           - '3.9'
-          - '3.8'
+          # - '3.8'
           # - '3.7'
     name: Python ${{ matrix.python }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         python:
           - '3.11'
           - '3.10'
-          # - '3.9'
-          # - '3.8'
-          # - '3.7'
+          - '3.9'
+          - '3.8'
+          - '3.7'
     name: Python ${{ matrix.python }}
     steps:
       # Python
@@ -46,7 +46,14 @@ jobs:
 
       # Tests
       - name: Run tests
-        run: pytest --ignore=tests/test_pattern_matching.py
+        run: pytest --ignore=tests/test_pattern_matching.py --ignore=tests/type-checking/test_result.yml
+      - name: Run tests (type checking)
+        if: matrix.python != '3.7' && matrix.python != '3.8' && matrix.python != '3.9'
+        # These started breaking for <= 3.9, due to the type checker using a
+        # '|' for unions rather than 'Union[...]', so it's not possible to run
+        # the tests without maintaining two duplicate files (one for <= 3.9 and
+        # one for > 3.9)
+        run: pytest tests/type-checking/test_result.yml
       - name: Run tests (pattern matching)
         if: matrix.python == '3.10' || matrix.python == '3.11'
         run: pytest tests/test_pattern_matching.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python:
           - '3.11'
           - '3.10'
-          - '3.9'
+          # - '3.9'
           # - '3.8'
           # - '3.7'
     name: Python ${{ matrix.python }}


### PR DESCRIPTION
I think mypy or pytest-mypy-plugins updated for python > 3.9, which changed union messages from `Union[...]` to `|`.

I also tried,
```python
if sys.version_info >= (3, 10):                                                                                                                                                                                                                                              
    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Ok[float] | Err[Exception]", variable has type "Ok[int] | Err[TypeError]")  [assignment]
else:                                                                                                                               
    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Union[Ok[float], Err[Exception]]", variable has type "Union[Ok[int], Err[TypeError]]")  [assignment]
```

But that didn't seem to work locally on python 3.11

For now I'm just disabling type checking tests for <= 3.9