### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests
         run: pytest --ignore=tests/test_pattern_matching.py --ignore=tests/type-checking/test_result.yml
       - name: Run tests (type checking)
-        if: matrix.python != '3.7' && matrix.python != '3.8' && matrix.python != '3.9'
+        if: matrix.python != '3.8' && matrix.python != '3.9'
         # These started breaking for <= 3.9, due to the type checker using a
         # '|' for unions rather than 'Union[...]', so it's not possible to run
         # the tests without maintaining two duplicate files (one for <= 3.9 and
@@ -60,10 +60,10 @@ jobs:
       # Linters
       - name: Run flake8 (Python >= 3.10)
         run: flake8
-        if: matrix.python != '3.9' && matrix.python != '3.8' && matrix.python != '3.7'
+        if: matrix.python != '3.9' && matrix.python != '3.8'
       - name: Run flake8 (Python < 3.10)
         run: flake8 --extend-exclude tests/test_pattern_matching.py
-        if: matrix.python == '3.9' || matrix.python == '3.8' || matrix.python == '3.7'
+        if: matrix.python == '3.9' || matrix.python == '3.8'
       - name: Run mypy
         run: mypy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
     name: Python ${{ matrix.python }}
     steps:
       # Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Possible log types:
 
 ## [Unreleased]
 
-- `[removed]` Drop support for Python 3.7 (#todo)
+- `[removed]` Drop support for Python 3.7 (#126)
 
 ## [0.11.0] - 2023-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+## [Unreleased]
+
+- `[removed]` Drop support for Python 3.7 (#todo)
+
 ## [0.11.0] - 2023-06-11
 
 - `[changed]` `Ok` now requires an explicit value during instantiation. Please

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -28,7 +27,7 @@ install_requires =
 package_dir =
     =src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = True
 
 [options.packages.find]

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -8,7 +8,9 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Final,
     Generic,
+    Literal,
     NoReturn,
     Type,
     TypeVar,
@@ -16,9 +18,9 @@ from typing import (
 )
 
 if sys.version_info >= (3, 10):
-    from typing import Final, Literal, ParamSpec, TypeAlias
+    from typing import ParamSpec, TypeAlias
 else:
-    from typing_extensions import Final, Literal, ParamSpec, TypeAlias
+    from typing_extensions import ParamSpec, TypeAlias
 
 
 T = TypeVar("T", covariant=True)  # Success type

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,py310,py39,py38,py37
+envlist = py311,py310,py39,py38
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Python 3.7 reached end-of-life a few days ago, so it's time to drop support for it.

This doesn't result in significant upgrade potential to the code base; it only makes us slightly less dependent on `typing_extensions`.