### PR TITLE
Fix the match args to use the correct attributes

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -38,7 +38,7 @@ class Ok(Generic[T]):
     """
 
     _value: T
-    __match_args__ = ("value",)
+    __match_args__ = ("ok_value",)
     __slots__ = ("_value",)
 
     def __init__(self, value: T) -> None:
@@ -185,7 +185,7 @@ class Err(Generic[E]):
     A value that signifies failure and which stores arbitrary data for the error.
     """
 
-    __match_args__ = ("value",)
+    __match_args__ = ("err_value",)
     __slots__ = ("_value",)
 
     def __init__(self, value: E) -> None:


### PR DESCRIPTION
The 'value' property is deprecated and instead 'ok_value' and 'err_value' must be used for 'Ok' and 'Err'. Due to the value for `__match_args__` not being updated, the deprecation warning was being raised when the user is using the `match` statement.

This fixes #127.