### PR TITLE
Remove the `_value: T` declaration from the Ok class

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -37,7 +37,6 @@ class Ok(Generic[T]):
     A value that indicates success and which stores arbitrary data for the return value.
     """
 
-    _value: T
     __match_args__ = ("ok_value",)
     __slots__ = ("_value",)
 


### PR DESCRIPTION
Looking at well-typed code bases like FastAPI and Starlette, there doesn't seem to be any precedent for declaring the field separately outside the `__init__` method params. So this PR removes the `_value: T` field declaration in the `Ok` class. The `Err` class already didn't have it