### PR TITLE
Improve `unwrap`/`expect` error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Possible log types:
 
 ## [Unreleased]
 
+- `[changed]` Include captured `Err` value when `expect` and `unwrap` are called and an `UnwrapError` is raised (#98, #132)
+
 ## [0.12.0] - 2023-06-11
 
 - `[removed]` Drop support for Python 3.7 (#126)

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -232,7 +232,16 @@ class Err(Generic[E]):
         """
         Raises an `UnwrapError`.
         """
-        raise UnwrapError(self, "Called `Result.unwrap()` on an `Err` value")
+        if isinstance(self.value, Exception):
+            raise UnwrapError(
+                self,
+                f"Called `Result.unwrap()` on an `Err` value: {self.value.__repr__()}",
+            ) from self.value
+        else:
+            raise UnwrapError(
+                self,
+                f"Called `Result.unwrap()` on an `Err` value: {self.value.__repr__()}",
+            )
 
     def unwrap_err(self) -> E:
         """

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -220,7 +220,13 @@ class Err(Generic[E]):
         """
         Raises an `UnwrapError`.
         """
-        raise UnwrapError(self, message)
+        exc = UnwrapError(
+            self,
+            f"{message}: {self.value!r}",
+        )
+        if isinstance(self.value, BaseException):
+            raise exc from self.value
+        raise exc
 
     def expect_err(self, _message: str) -> E:
         """
@@ -232,16 +238,13 @@ class Err(Generic[E]):
         """
         Raises an `UnwrapError`.
         """
-        if isinstance(self.value, Exception):
-            raise UnwrapError(
-                self,
-                f"Called `Result.unwrap()` on an `Err` value: {self.value.__repr__()}",
-            ) from self.value
-        else:
-            raise UnwrapError(
-                self,
-                f"Called `Result.unwrap()` on an `Err` value: {self.value.__repr__()}",
-            )
+        exc = UnwrapError(
+            self,
+            f"Called `Result.unwrap()` on an `Err` value: {self.value!r}",
+        )
+        if isinstance(self.value, BaseException):
+            raise exc from self.value
+        raise exc
 
     def unwrap_err(self) -> E:
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -64,6 +64,21 @@ def test_err() -> None:
     assert res.value == ':('
 
 
+def test_err_value_is_exception() -> None:
+    res = Err(ValueError("Some Error"))
+    assert res.is_ok() is False
+    assert res.is_err() is True
+
+    with pytest.raises(UnwrapError):
+        res.unwrap()
+
+    try:
+        res.unwrap()
+    except UnwrapError as e:
+        cause = e.__cause__
+        assert isinstance(cause, ValueError)
+
+
 def test_ok_method() -> None:
     o = Ok('yay')
     n = Err('nay')


### PR DESCRIPTION
Continuation of https://github.com/rustedpy/result/pull/100
Fixes https://github.com/rustedpy/result/issues/98

Makes the captured `Err` value visible in the error message when `expect` or `unwrap` is called