### PR TITLE
Add `is_ok` and `is_err` typeguard functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Possible log types:
 
 ## [Unreleased]
 
+- `[added]` `is_ok` and `is_err` type guard functions. A faster alternative to `isinstance` checks (#69)
+
 ## [0.13.1] - 2023-07-19
 
 - `[fixed]`  Use `self._value` instead of deprecated `self.value` in `Err.expect` and `Err.unwrap` to avoid raising a warning (#133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Possible log types:
 
 ## [Unreleased]
 
-- `[added]` `is_ok` and `is_err` type guard functions. A faster alternative to `isinstance` checks (#69)
+-- `[added]` `is_ok` and `is_err` type guard functions as alternatives to `isinstance` checks (#69)
 
 ## [0.13.1] - 2023-07-19
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ To something like this:
 
 .. sourcecode:: python
 
-    from result import Ok, Err, Result
+    from result import Ok, Err, Result, is_ok, is_err
 
     def get_user_by_email(email: str) -> Result[User, str]:
         """
@@ -74,10 +74,10 @@ To something like this:
         return Ok(user)
 
     user_result = get_user_by_email(email)
-    if isinstance(user_result, Ok):
+    if isinstance(user_result, Ok): # or `is_ok(user_result)`
         # type(user_result.value) == User
         do_something(user_result.value)
-    else:
+    else: # or `elif is_err(user_result)`
         # type(user_result.value) == str
         raise RuntimeError('Could not fetch user: %s' % user_result.value)
 
@@ -120,7 +120,8 @@ Creating an instance:
     >>> res1 = Ok('yay')
     >>> res2 = Err('nay')
 
-Checking whether a result is ``Ok`` or ``Err``. With ``isinstance`` you get type safe
+Checking whether a result is ``Ok`` or ``Err``. You can either use ``is_ok`` and ``is_err`` functions
+or ``isinstance``. This way you get type safe.
 access that can be checked with MyPy. The ``is_ok()`` or ``is_err()`` methods can be
 used if you don't need the type safety with MyPy:
 
@@ -129,7 +130,11 @@ used if you don't need the type safety with MyPy:
     >>> res = Ok('yay')
     >>> isinstance(res, Ok)
     True
+    >>> is_ok(res)
+    True
     >>> isinstance(res, Err)
+    False
+    >>> is_err(res)
     False
     >>> res.is_ok()
     True

--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -1,4 +1,14 @@
-from .result import Err, Ok, OkErr, Result, UnwrapError, as_async_result, as_result
+from .result import (
+    Err,
+    Ok,
+    OkErr,
+    Result,
+    UnwrapError,
+    as_async_result,
+    as_result,
+    is_ok,
+    is_err,
+)
 
 __all__ = [
     "Err",
@@ -8,5 +18,7 @@ __all__ = [
     "UnwrapError",
     "as_async_result",
     "as_result",
+    "is_ok",
+    "is_err",
 ]
 __version__ = "0.14.0.dev0"

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -18,9 +18,9 @@ from typing import (
 )
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec, TypeAlias
+    from typing import ParamSpec, TypeAlias, TypeGuard
 else:
-    from typing_extensions import ParamSpec, TypeAlias
+    from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 
 
 T = TypeVar("T", covariant=True)  # Success type
@@ -82,8 +82,8 @@ class Ok(Generic[T]):
         removed in a future version.
         """
         warn(
-            "Accessing `.value` on Result type is deprecated, please use " +
-            "`.ok_value` or '.err_value' instead",
+            "Accessing `.value` on Result type is deprecated, please use "
+            + "`.ok_value` or '.err_value' instead",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -229,8 +229,8 @@ class Err(Generic[E]):
         removed in a future version.
         """
         warn(
-            "Accessing `.value` on Result type is deprecated, please use " +
-            "`.ok_value` or '.err_value' instead",
+            "Accessing `.value` on Result type is deprecated, please use "
+            + "`.ok_value` or '.err_value' instead",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -441,3 +441,31 @@ def as_async_result(
         return async_wrapper
 
     return decorator
+
+
+def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
+    """A typeguard to check if a result is an Ok
+
+    Usage:
+    >>> result = Ok(1)
+    >>> err = Err("error")
+    >>> if is_ok(result):
+    >>>     reveal_type(result)  # Revealed type is 'Ok[builtins.int*]'
+    >>> elif is_err(err):
+    >>>     reveal_type(err)  # Revealed type is 'Err[builtins.str*]'
+    """
+    return result.is_ok()
+
+
+def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
+    """A typeguard to check if a result is an Err
+
+    Usage:
+    >>> result = Ok(1)
+    >>> err = Err("error")
+    >>> if is_ok(result):
+    >>>     reveal_type(result)  # Revealed type is 'Ok[builtins.int*]'
+    >>> elif is_err(err):
+    >>>     reveal_type(err)  # Revealed type is 'Err[builtins.str*]'
+    """
+    return result.is_err()

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -447,12 +447,11 @@ def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
     """A typeguard to check if a result is an Ok
 
     Usage:
-    >>> result = Ok(1)
-    >>> err = Err("error")
-    >>> if is_ok(result):
-    >>>     reveal_type(result)  # Revealed type is 'Ok[builtins.int*]'
-    >>> elif is_err(err):
-    >>>     reveal_type(err)  # Revealed type is 'Err[builtins.str*]'
+    >>> r: Result[int, str] = get_a_result()
+    >>> if is_ok(r):
+    >>>     r   # r is of type Ok[int]
+    >>> elif is_err(r):
+    >>>     r   # r is of type Err[str]
     """
     return result.is_ok()
 
@@ -461,11 +460,10 @@ def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
     """A typeguard to check if a result is an Err
 
     Usage:
-    >>> result = Ok(1)
-    >>> err = Err("error")
-    >>> if is_ok(result):
-    >>>     reveal_type(result)  # Revealed type is 'Ok[builtins.int*]'
-    >>> elif is_err(err):
-    >>>     reveal_type(err)  # Revealed type is 'Err[builtins.str*]'
+    >>> r: Result[int, str] = get_a_result()
+    >>> if is_ok(r):
+    >>>     r   # r is of type Ok[int]
+    >>> elif is_err(r):
+    >>>     r   # r is of type Err[str]
     """
     return result.is_err()

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -81,3 +81,15 @@
 
     personalized_greeting = personalized_greeting_res.ok()
     reveal_type(personalized_greeting) # N: Revealed type is "Union[builtins.str, None]"
+
+- case: map_result
+  disable_cache: false
+  main: |
+    from result import Ok, Err, is_ok, is_err
+
+    result = Ok(1)
+    err = Err("error")
+    if is_ok(result):
+        reveal_type(result)  # N: Revealed type is "result.result.Ok[builtins.int]"
+    elif is_err(err):
+        reveal_type(err)  # N: Revealed type is "result.result.Err[builtins.str]"


### PR DESCRIPTION
I'd say this is a more performant implementation than #72 as it doesn't use `is instance` checks at all.

Added tests, changelog & took a stab at main readme (although this is up to maintainers, whether this should be advertised as a better approach).

On my laptop one of the mypy tests is failing on 3.9, but that's not related to my change (complains about `|` where `Union` should be)

closes #69