### PR TITLE
added piping, filtering and multivariate functions

### DIFF
--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -8,6 +8,8 @@ from .result import (
     as_result,
     is_ok,
     is_err,
+    MultiResult,
+    FilterException,
 )
 
 __all__ = [
@@ -20,5 +22,7 @@ __all__ = [
     "as_result",
     "is_ok",
     "is_err",
+    "MultiResult",
+    "FilterException",
 ]
 __version__ = "0.14.0.dev0"

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -16,11 +16,17 @@ from typing import (
     TypeVar,
     Union,
 )
+from collections.abc import Sequence
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeAlias, TypeGuard
 else:
     from typing_extensions import ParamSpec, TypeAlias, TypeGuard
+
+if sys.version_info < (3,11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 
 T = TypeVar("T", covariant=True)  # Success type
@@ -177,6 +183,80 @@ class Ok(Generic[T]):
         The contained result is `Ok`, so return `Ok` with the original value
         """
         return self
+
+    ## piping
+    def __matmul__(self, op: Callable[[T],U]) -> Result[U,Exception]:
+        """
+        Piping operator, which returns Err on exception encounter.
+
+        Example:
+            res: Result = Ok(2) @ (lambda x: x**2) @ (lambda x: x+1)
+            assert res.unwrap() == 5
+        """
+
+        try:
+            return Ok(op(self._value))
+        except Exception as exc:
+            fnc = op.__name__
+            lastVal = self.ok_value
+            exc.args = tuple( [a for a in exc.args] + [f'{fnc=}',f'{lastVal=}'] )
+            return Err(exc)
+
+    async def __ge__(self, op:Callable[[T],Awaitable[U]]) -> Result[U,Exception]:
+        """
+        Piping for async functions.
+        The operator CANNOT chain without await
+
+        Example:
+            async def foo(x): return x+1
+            x = Ok(2) >= foo
+            result = await x
+            assert result == Ok(3)
+
+            ## can be inlined with parentheses, but make sure to LEAVE SPECE AFTER AWAIT
+            y = await (await ( Ok(2) >= foo ) @ (lambda x: x+1) >= foo)
+            assert y == Ok(5)
+        """
+
+        try:
+            result = await op(self._value)
+            return Ok(result)
+        except Exception as exc:
+            fnc = op.__name__
+            lastVal = self.ok_value
+            exc.args = tuple( [a for a in exc.args] + [f'{fnc=}',f'{lastVal=}'] )
+            return Err(exc)
+
+    def __mod__(self, op: Callable[[T],bool]) -> Result[T,FilterException]:
+        """
+        pipe filter; TRUE => keep the Ok value
+
+        filtered values are treated as errors
+        see below the FilterException
+
+        Example:
+            res: Result = Ok(2) @ (lambda x: x**2) % (lambda x: x>10) @ (lambda x: x+1)
+            assert isinstance(res, Err)
+            assert res._value._result == Ok(4) ## traceback on where it stopped in the chain
+            assert res. (..traceback..) .`reason` == 'filtered out' ## mark, that it was deliberately filtered
+        """
+
+        if op(self._value):
+            return self
+        else:
+            value = self.ok_value
+            filterFnc = op.__name__
+            err = FilterException(self, "filtered out", f"{value=}" ,f"{filterFnc=}")
+            return Err(err)
+
+    def __or__(self, other:Result[Any,Any]) -> MultiResult:
+        """
+        Joining operator. If not specified manually, the Result needs to initialize MultiResult instance.
+        Example:
+            mres: MultiResult = Ok(2) | Ok(12)
+            assert tuple(mres.results) == tuple([ Ok(2) , Ok(12) ])
+        """
+        return MultiResult(self, other)
 
 
 class Err(Generic[E]):
@@ -336,6 +416,295 @@ class Err(Generic[E]):
         """
         return op(self._value)
 
+    ## piping
+    def __matmul__(self, op: Callable[[T],U]) -> Result[U,E]:
+        """
+        Piping operator, 
+        already an Error, so just returns self.
+
+        Example:
+            assert Err(2) @ (lambda x:x**2) == Err(2)
+        """
+        return self
+    
+    async def __ge__(self, op:Callable[[T],Awaitable[U]]) -> Result[U,E]:
+        """
+        Piping for async functions.
+        Just returns self, but needs to be awaited to have the same behavoiur as the Ok variant.
+        The operator CANNOT chain without await
+
+        Example:
+            async def foo(x): return x+1
+            x = Err('foo') >= foo
+            result = await x
+            assert result == Err('foo')
+
+            ## can be inlined with parentheses, but make sure to LEAVE SPECE AFTER AWAIT
+            y = await (await ( Err('bar') >= foo ) @ (lambda x: x+1) >= foo)
+            assert y == Err('bar')
+
+        """
+        return self
+
+    def __mod__(self, op: Callable[[T],bool]) -> Result[T,E]:
+        """
+        pipe filter.
+        filtered values are treaded as errors
+        returns self, since it's already an error
+        """
+        return self
+
+    def __or__(self, other:Result[Any,Any]) -> MultiResult:
+        """
+        Joining operator. If not specified manually, the Result needs to initialize MultiResult instance.
+        Example:
+            mres: MultiResult = Ok(2) | Ok(12)
+            assert tuple(mres.results) == tuple([ Ok(2) , Ok(12) ])
+        """
+        return MultiResult(self, other)
+
+
+class MultiResult:
+    """
+    A Result class for storing (joining) multiple results to use in multivariate functions.
+    The multivariate operator has the lower priority so it gets evaluated AFTER:
+        - single argument functions ( Result @ fnc -> Result )
+        - result joining ( Result | Result -> MultiResult )
+        - finally then: ( MultiResult > multivarfnc -> Result )
+        - similarly for async: ( MultiResult >= async multifnc -> coroutine ) ... this needs to be awaited
+    """
+
+    __match_args__ = ("results",)
+    __slots__ = ("results",)
+
+    def __init__(self, *results: Result[Any,Any]) -> None:
+        self.results = list(results)
+
+    def __repr__(self) -> str:
+        results = [str(res) for res in self.results]
+        return 'MultiResult('+','.join(results)+')' 
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, MultiResult)\
+            and (n:=len(self.results)) == len(other.results)\
+            and all( [ self.results[i] == other.results[i] for i in range(n) ] )
+
+    def __ne__(self, other: Any) -> bool:
+        return not (self == other)
+
+    def __hash__(self) -> int:
+        """
+        hash by repr if normal fails
+        """
+        try:
+            return hash(tuple( hash(res) for res in self.results ) )
+        except:
+            return hash(repr(self))
+
+    def is_ok(self) -> bool:
+        return all( [ res.is_ok() for res in self.results ] )
+
+    def is_err(self) -> bool:
+        return not self.is_ok()
+
+    def ok(self) -> tuple[Any,...]:
+        """
+        Return the ok values or Nones for errors.
+
+        Example:
+            assert ( Ok(2) | Ok('foobar') | Err('magnets')  ).ok() == (2,'foobar',None)
+        """
+        return tuple(res.ok() for res in self.results)
+
+    def err(self) -> tuple[Any,...]:
+        """
+        returns the error values or Nones for oks.
+
+        Example:
+            assert ( Ok(2) | Ok('foobar') | Err('magnets')  ).ok() == (None,None,'magnets')
+        """
+        return tuple(res.err() for res in self.results)
+
+    def expect(self, _message: str) -> tuple[Any,...]:
+        """
+        Attempts to return tuple of values.
+
+        Raises:
+            UnwrapError with `_message` if any element fails
+        """
+        return tuple(res.expect(_message) for res in self.results)
+
+    def expect_err(self, _message: str) -> Exception:
+        """
+        If successfully unwraps, raises.
+        Otherwise returns the (first?) error.
+        """
+        try:
+            val = self.unwrap()
+            raise UnwrapError(Ok(val),_message)
+        except Exception as e:
+            return e
+
+    def unwrap(self) -> tuple[Any,...]:
+        """
+        Attempts to return tuple of values.
+
+        Raises:
+            UnwrapError with `_message` if any element fails
+        """
+        return tuple(res.unwrap() for res in self.results)
+
+    def unwrap_error(self) -> tuple[Any,...]:
+        if self.is_ok():
+            raise UnwrapError(Ok(self.unwrap()), "Called `Result.unwrap_err()` on an `Ok` value")
+        return self.err()
+
+    def unwrap_or(self, _default: Sequence[Any]) -> tuple[Any,...]:
+        """
+        Tries to unwrap as much as possible, returns relevant `_default` on partial fails.
+        `_default` needs to be at least the result length.
+
+        Example:
+            multi = Ok(3) | Err('foo')
+            assert multi.unwrap_or( [42, 69, 13,14,15,...] ) == (3,69)
+        """
+        return tuple(res.unwrap_or(_default[i]) for i,res in enumerate(self.results))
+
+
+    def unwrap_or_else(self, op: Callable[[Sequence[Result[Any,Any]]],U]) -> tuple[Any,...] | U:
+        """
+        Tries to unwrap, returns relevant `op` on fail.
+        `op` takes sequence of results as argument.
+
+        Example:
+            def _log_errors(results) -> None: log([f'unwrap_fail, {res.err()}' for res in results if res.is_err()])
+            multi = Ok(3) | Err('foo')
+            assert multi.unwrap_or( log_errors ) == None
+        """
+        if self.is_ok():
+            return self.unwrap()
+        else:
+            return op(self.results)
+
+    def unwrap_or_raise(self, e: Type[TBE]) -> tuple[Any,...]:
+        """
+        Return the value.
+        if any element fails, it raises according to its error value.
+        """
+        return tuple(res.unwrap_or_raise(e) for res in self.results)
+
+    def map(self, op: Callable[...,U]) -> Result[U,Exception]:
+        """
+        unwraps and maps
+
+        """
+        try:
+            return Ok(op(*self.unwrap()))
+        except Exception as e:
+            return Err(e)
+
+    def map_or(self, default: U, op: Callable[...,U]) -> U: 
+        """
+        Tries to map, otherwise returns the default object.
+        """
+        if self.is_ok():
+            return op(*self.unwrap())
+        else:
+            return default
+
+    def map_or_else(self, default_op: Callable[[],U], op: Callable[..., U]) -> U:
+        """
+        Tries to map, otherwise performs and returns the default `op`.
+        """
+        if self.is_ok():
+            return op(*self.unwrap())
+        else:
+            return default_op()
+
+    def map_err(self, op: Callable[[Sequence[Any]], F]) -> Result[tuple[Any,...],F]:
+        """
+        Creates Result from the MultiResult.
+        This operation joins several results into a tuple one.
+        If no error is present, turn into unwrapped Ok.
+        If any error is present, turn into simple error.
+        """
+        if self.is_err():
+            return Err(op(self.err()))
+        else:
+            return Ok(self.unwrap())
+
+    def or_else(self, op: Callable[[Self],Self]) -> Self:
+        """
+        this operation ensures that the output is OkMultiResult
+        tries to return self if its ok
+        otherwise calls and returns the multiresult from fnc
+        """
+        if self.is_ok():
+            return self
+        else:
+            return op(self)
+
+
+    ## piping
+    def __or__(self, result: Result[U,E]) -> Self:
+        """
+        operator that appends new result to the multiresult list
+        
+        Example:
+            multires: MultiResult = Ok(12) @ (lambda x:x-10) | Ok('hello') | Ok([1,2,3]) @ (lambda x:sum(x))
+            assert multires.unwrap() == (2, 'hello', 6)
+            assert multires.ok()     == (2, 'hello', 6)
+            assert multires.err()    == (None,None,None)
+        """
+        self.results += [result]
+        return self
+
+    def __gt__(self, op: Callable[...,U]) -> Result[U,Exception]:
+        """
+        operator which performs mapping of internal vals through the `op`
+        expects sinngular return value
+        
+        Example:
+            res: Result = Ok(1) | Ok(2) > (lambda x,y: x+y)
+            assert res.unwrap() == 3
+
+            res2: Result = Ok(1) | Err(exc) > (lambda x,y: ...)
+            assert isinstance(res2, Err)
+        """
+        try:
+            vals = [res.unwrap() for res in self.results]
+            return Ok(op(*vals ))
+        except Exception as e:
+            errmsg = 'err_elements:'+', '.join([str(res) for res in self.results if res.is_err()]) 
+            fnc = op.__name__
+            errlist = [ 'erroneous input', f"{fnc=}", errmsg ]
+            return Err(Exception(*errlist))
+
+    async def __ge__(self, op: Callable[...,Awaitable[U]]) -> Result[U,Exception]:
+        """
+        async pipe
+        operator which performs mapping of internal vals through the `op`
+        The operator CANNOT chain without await
+
+        Example:
+            async def foo(x,y): return x*y
+            res = await(
+                Ok(2) @ (lambda x: x*2)
+                | Ok(4) @ (lambda x: x-1)
+                >= foo 
+                )
+            assert res == Ok(12)
+        """
+        try:
+            vals = [res.unwrap() for res in self.results]
+            return Ok(await op(*vals ))
+        except Exception as e:
+            errmsg = 'err_elements:'+', '.join([str(res) for res in self.results if res.is_err()]) 
+            fnc = op.__name__
+            errlist = [ 'erroneous input', f"{fnc=}", errmsg ]
+            return Err(Exception(*errlist))
+
+
 
 # define Result as a generic type alias for use
 # in type annotations
@@ -352,6 +721,8 @@ This is purely for convenience sake, as you could also just write `isinstance(re
 """
 OkErr: Final = (Ok, Err)
 
+
+### errors and exceptions
 
 class UnwrapError(Exception):
     """
@@ -377,6 +748,32 @@ class UnwrapError(Exception):
         """
         return self._result
 
+class FilterException(Exception):
+    """
+    Exception raised from filter pipe.
+
+    The original ``Result`` can be accessed via the ``.result`` attribute, but
+    this is not intended for regular use, as type information is lost:
+    ``UnwrapError`` doesn't know about both ``T`` and ``E``, since it's raised
+    from ``Ok()`` or ``Err()`` which only knows about either ``T`` or ``E``,
+    not both.
+    """
+
+    _result: Result[object, object]
+
+    def __init__(self, result: Result[object, object], *message: str) -> None:
+        self._result = result
+        super().__init__(*message)
+
+    @property
+    def result(self) -> Result[Any, Any]:
+        """
+        Returns the original result.
+        """
+        return self._result
+
+
+############### wrappers
 
 def as_result(
     *exceptions: Type[TBE],

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+from typing import Callable, Sequence, Any
+
+import pytest
+
+from result import Err, Ok, OkErr, Result, UnwrapError, as_async_result, as_result, MultiResult
+
+
+def test_MultiResult_factories() -> None:
+   x = Ok(1)
+   y = Ok(2)
+   z = Ok([1,2,3])
+   instance = x | y | z
+
+   assert instance.unwrap() == (1,2, [1,2,3])
+   assert instance.expect('errors present') == (1,2, [1,2,3])
+   assert instance.is_ok()
+
+def test_eq() -> None:
+   assert MultiResult(Ok(1), Ok('foo')) == MultiResult(Ok(1), Ok('foo'))
+   assert MultiResult(Err(1), Ok([1,2,3])) == MultiResult(Err(1), Ok([1,2,3]))
+   assert MultiResult(Ok(1)) != MultiResult(Err(1))
+   assert MultiResult( Ok({"foo":"bar", 3:[1,2,3]}) ) == MultiResult( Ok({"foo":"bar", 3:[1,2,3]}) )
+
+
+def test_hash() -> None:
+    # lists, sets, dicts ... are unhashable!
+    hash1 = hash(MultiResult( Ok(1), Ok(1.1), Err('foo') ))
+    hash2 = hash(MultiResult( Ok(1), Ok(1.1), Err('foo') ))
+    assert hash1 == hash2
+
+    hash3 = hash(MultiResult( Ok([1,2,3]), Ok({1,2,3}), Err('foo') ))
+    hash4 = hash(MultiResult( Ok([1,2,3]), Ok({1,2,3}), Err('foo') ))
+    assert hash3 == hash4
+
+
+def test_repr() -> None:
+    """
+    ``repr()`` returns valid code if the wrapped value's ``repr()`` does as well.
+    """
+    o = Ok(123)
+    n = Err(-1)
+    mr = MultiResult(o,n)
+
+    assert repr(mr) == "MultiResult(Ok(123),Err(-1))"
+    assert mr == eval(repr(mr))
+
+    mr = mr | Ok({"foo":[1,2,3], 3:{3:1,2:9}}) #| Err(Exception("foobar"))
+                                                ## exception fails test
+    assert mr == eval(repr(mr))
+
+
+def test_ok_err_values() -> None:
+    x = Ok('haha')
+    y = Err('boo')
+    mr = x|y
+
+    assert mr.ok() == ('haha',None)
+    assert mr.err() == (None, 'boo')
+    assert mr.is_ok() == False
+    assert mr.is_err() == True
+            ## at least 1 error
+
+def test_err_value_is_exception() -> None:
+    err = Err(ValueError("Some Error"))
+    mr = MultiResult( err )    
+
+    assert mr.is_err() == True
+
+    with pytest.raises(UnwrapError):
+        mr.unwrap()
+
+    try:
+        mr.unwrap()
+    except UnwrapError as e:
+        cause = e.__cause__
+        assert isinstance(cause, ValueError)
+
+
+def test_unwrap() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    z = Ok('foo')
+    mrbad = o|n|z
+    mrok = o|z
+
+    assert mrok.unwrap() == ('yay', 'foo')
+    with pytest.raises(UnwrapError):
+        mrbad.unwrap()
+
+
+def test_unwrap_or() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    z = Ok([1,2,3])
+    mr = o|n|z
+
+    defaults = ['some_default', 'another_default', 'some_default']
+    
+    unwrap = mr.unwrap_or(defaults)
+    assert unwrap[0] == 'yay'
+    assert unwrap[1] == 'another_default'
+    assert unwrap[2] == [1,2,3]
+
+
+def test_unwrap_or_else() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    z = Ok({1:11,2:"hello",3:[1,2,3]})
+    mr = o|n|z
+
+    def default_op(results: Sequence[Result[Any,Any]]) -> list[Any]:
+        out = []
+        for res in results:
+            if res.is_ok():
+                out += [ res.ok() ]
+            else:
+                out += [ str(res.err()).upper() ]
+        return out
+
+    unwrap = mr.unwrap_or_else(default_op)
+    assert unwrap[0] == 'yay'
+    assert unwrap[1] == 'NAY'
+    assert unwrap[2] == {1:11,2:"hello",3:[1,2,3]}
+
+def test_unwrap_or_raise() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    z = Ok('foo')
+    mrbad = o|n|z
+    mrok = o|z
+    
+
+    assert mrok.unwrap_or_raise(ValueError) == ('yay','foo')
+
+    with pytest.raises(ValueError) as exc_info:
+        mrbad.unwrap_or_raise(ValueError)
+    assert exc_info.value.args == ('nay',)
+
+
+def test_map() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    z = Ok([1,2,3])
+    
+    def mysum(x: list[int]) -> int:
+        return sum(x)
+
+    assert ( o @ str.upper ).ok() == 'YAY'
+    assert ( n @ str.upper ).err() == 'nay'
+    assert ( z @ mysum ).ok() == 6
+
+    num = Ok(3)
+    errnum = Err(2)
+
+    assert (num@str).ok() == '3'
+    assert (errnum@str).err() == 2
+
+    mrbad = o | n | z | num | errnum
+    resbad = mrbad > (lambda x:x)
+    assert resbad.is_err()
+
+    def fnc(o: str,z: list[int],num: int) -> str: 
+        return str(o) + str(sum(z)) + str(num)
+    res = o|z|num > fnc
+    assert res.is_ok()
+    assert res.unwrap() == 'yay63'
+
+
+def test_map_or() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    mrbad = o|n
+
+    alternative = Ok('haystack')
+    def fnc(o: str,n: int) -> Ok[str]: return Ok(''.join([o,str(n)]))
+    assert mrbad.map_or(alternative, fnc).ok() == 'haystack'
+
+    num = Ok(3)
+    mrgood = o|num
+    assert mrgood.map_or(alternative,fnc).ok() == 'yay3'
+
+def test_map_or_else() -> None:
+    o = Ok('yay')
+    n = Err('nay')
+    mrbad = o|n
+
+    def default_op() -> str: return 'baad'
+    def fnc(o:str,n:str) -> str: return ''.join((o,str(n)))
+    
+    assert mrbad.map_or_else(default_op, fnc) == 'baad'
+
+    num = Ok(3)
+    mrgood = o|num
+
+    assert mrgood.map_or_else(default_op, fnc) == 'yay3'
+
+
+
+def test_and_then() -> None:
+    """MultiResult doesnt have and_then.
+    its purpose is to be consumed."""
+
+def test_or_else() -> None:
+
+    def fix_mr( mr: MultiResult ) -> MultiResult:
+        return MultiResult(
+            *[ 
+                res if res.is_ok() else Ok(res._value+i+2) 
+                    for i,res in enumerate(mr.results) 
+             ]
+        )
+
+    x = Ok(2).or_else(sq).or_else(sq)         ## good
+    y = Ok(2).or_else(to_err).or_else(sq)  ## good
+
+    assert x.is_ok()
+    assert y.is_ok()
+    
+    mrgood = x|y
+    mrres = mrgood.or_else(fix_mr)
+    unwrap = mrres.unwrap()
+    assert unwrap == (2,2) 
+
+    w = Err(3).or_else(sq).or_else(to_err) ## good
+    z = Err(3).or_else(to_err).or_else(to_err)     ## bad
+
+    mrbad = x.and_then(sq) |w|z
+    mrres2 = mrbad.or_else(fix_mr)
+    unwrap2 = mrres2.unwrap()
+    assert unwrap2 == (4,9,7)
+
+
+def test_isinstance_result_type() -> None:
+    def add1(x: int) -> int: return x+1
+    def div2(x: int) -> float: return x/2
+
+    o = Ok(2) @ add1 @ div2
+    n = Err(1) @ add1
+    assert isinstance(o, OkErr)
+    assert isinstance(n, OkErr)
+
+
+def test_error_context() -> None:
+    n = Err('nay')
+    m = Err(13)
+    l = Err(Exception('foo'))
+    mr = n|m|l
+
+    with pytest.raises(UnwrapError) as exc_info:
+        mr.unwrap()
+    exc = exc_info.value
+    assert exc.result is n
+    ## MultiResult unwrap raises the first encountered exception
+
+
+def test_slots() -> None:
+    """
+    Ok and Err have slots, so assigning arbitrary attributes fails.
+    """
+    mr = MultiResult()
+    with pytest.raises(AttributeError):
+        mr.some_arbitrary_attribute = 1  # type: ignore[attr-defined]
+
+
+def test_function_piping() -> None:
+    def good(value: int) -> int:
+        return value
+
+    def bad(value: int) -> int:
+        raise ValueError
+
+    good_result = Ok(123) @ good
+    bad_result = Ok(123) @ bad
+
+    assert isinstance(good_result, Ok)
+    assert good_result.unwrap() == 123
+    assert isinstance(bad_result, Err)
+    assert isinstance(bad_result.unwrap_err(), ValueError)
+
+
+
+def test_piping_type_checking_simple() -> None:
+    def f(a: int) -> int:
+        return a
+
+    res: Result[int, Exception]
+    res = Ok(123) @ f  # No mypy error here. But piping assumes general Exceptions
+                        #    --> something to make better
+    assert res.ok() == 123
+
+def test_compound_types() -> None:
+    
+    def f(a:int, b:int) -> list[int]:
+        out = [ b*i for i in range(a) ]
+        return out
+
+    
+    res: Result[list[int], Exception]
+    res = Ok(5) | Ok(10) > f
+    
+    assert isinstance(res, Ok)
+    assert res.ok() == [0,10,20,30,40]
+
+def test_filtering() -> None:
+    from result import FilterException
+
+    x1 = Ok(2)
+    x2 = Ok(3)
+    y1 = x1 @ add1 % iseven
+    y2 = x2 @ add1 % iseven
+
+    assert isinstance(y1, Err)
+    assert isinstance(y2, Ok)
+    assert y2.ok() == 4
+
+    
+    with pytest.raises(FilterException):
+        raise y1.err()
+
+def test_generators() -> None:
+    xs = [
+        Ok(i)
+        @ square
+        @ add1
+        @ mod2
+        @ add2
+        @ square
+        for i in range(10)
+    ]
+
+    mr = MultiResult(*xs)
+    assert mr.is_ok()
+
+    unwrap = mr.unwrap()
+    assert unwrap == (9,4,9,4,9,4,9,4,9,4)
+
+def test_generator_with_filter() -> None:
+    xs = [ 
+        res for i in range(10)
+        if (res:= Ok(i)
+           @ add2
+           @ cube
+           % iseven ## filter -> only even (i+2)**3 will remain
+           @ mod2
+           @ add2
+           @ add2
+           @ square
+           % ge10   ## filter -> only those <= 10 here will remain
+           @ sub1
+           @ cube
+        ).is_ok()   ## the final check which will remove all Errors
+    ]
+
+    mr = MultiResult(*xs)
+    assert mr.is_ok()
+
+    unwrap = mr.unwrap()
+    assert unwrap == (3375,3375,3375,3375,3375)
+
+def test_larger_multivar_function() -> None:
+    """
+    do not remove the errors apriori at this time
+    """
+    from math import isclose
+
+    xs = [
+        Ok(i)
+        @ add1
+        @ square
+        % ge10
+        @ div1
+        @ add1
+        @ cube
+
+        for i in range(10)
+    ]
+
+    mr = MultiResult(*xs)
+    assert mr.is_err()
+
+    clean_xs = [x for x in xs if x.is_ok()]
+    mrgood = MultiResult(*clean_xs)
+    assert mrgood.is_ok()
+    unwrap = mrgood.unwrap()
+
+    assert len(unwrap) == 7
+
+    def mysum(*x: float) -> float:
+        return sum(x)
+
+    res: Result[float, Exception]
+    res = mrgood > mysum
+    assert res.is_ok()
+    value = res.ok()
+    assert value is not None
+    assert isclose(value, 7.58, abs_tol = 1e-2)
+
+
+
+@pytest.mark.asyncio
+async def test_async_pipes_simple() -> None:
+
+    async def good(value: int) -> int:
+        return value
+
+    async def bad(value: int) -> int:
+        raise ValueError
+
+    good_result = await (Ok(123) >= good)
+    bad_result = await (Ok(123) >= bad)
+
+    assert isinstance(good_result, Ok)
+    assert good_result.unwrap() == 123
+    assert isinstance(bad_result, Err)
+    assert isinstance(bad_result.unwrap_err(), ValueError)
+
+@pytest.mark.asyncio
+async def test_async_multivar_pipe() -> None:
+    from math import isclose
+
+    async def fnc(x: int, y: float, z: float) -> float:
+        return (x+y)/z
+
+    res = await (Ok(5) | Ok(2.5) | Ok(0.5) >= fnc)
+
+    assert isinstance(res, Ok)
+    assert isclose(res.ok(), 15)
+
+Number = float | int
+
+##############################################################
+## function declarations for mypy testing
+##############################################################
+
+def tee(x: Number) -> Number:
+    print(f"{x=}")
+    return x
+
+## functions
+def square(x: Number) -> Number:
+    return x*x
+def cube(x: Number) -> Number:
+    return x*x*x
+def mod2(x: Number) -> Number:
+    return x%2
+def div1(x: Number) -> Number:
+    return 1/x
+def add1(x: Number) -> Number:
+    return x+1
+def sub1(x: Number) -> Number:
+    return x-1
+def div10(x:Number) -> Number:
+    return x/10
+def add2(x:Number) -> Number:
+    return x+2
+
+## filters
+def le50(x:Number) -> bool:
+    return x<=50
+def ge10(x:Number) -> bool:
+    return x>=10
+def iseven(x: Number) -> bool:
+    return x%2 == 0
+
+
+def sq(i: int) -> Result[int, int]:
+    return Ok(i * i)
+
+def to_err(i: int) -> Result[int, int]:
+    return Err(i)
+
+# Lambda versions of the same functions, just for test/type coverage
+sq_lambda: Callable[[int], Result[int, int]] = lambda i: Ok(i * i)
+to_err_lambda: Callable[[int], Result[int, int]] = lambda i: Err(i)
+


### PR DESCRIPTION
- seamless monads via: Ok(val) @ fnc @ fnc2 ... --> Result[]
  - try-catch exceptions and turn them into errors
  - no need to decorate the functions, just start with a Result and pipe
  - no need to unwrap, match, or check much
- filtering: Ok(val) % filter_fnc @ fnc ...
  - unwanted values get turned into Errors with FilterException
  - can be used in comphehensions with `.is_ok()`
- added multivariate functions: Ok(x) | Ok(y) > fnc(a,b) ---> Result[]
  - output of the `|` operator is MultiResult class with tuple values
  - `>` need to be last in pipeline or escaped with parentheses due to operator precedence
  - errors are catched and traced (thou this shoould be done better..)
  - can be used for zipping or reduction
- asynchronous piping via: await ( Ok(x) >= asfnc(x) ) @ fnc @ ...
  - need to be awaited or last in the pipeline (retudns courutine)
  - works for multivariate functions as well: await ( Ok(x)|Ok(y) >= fnc )
- tests and mypy are happy

comprehension:
[ res for i in range(..) if (res:= Ok(i) @ .. % .. @ .. ).is_ok() ]

... the list can be turned to MultiResult instance for reduction in fncs.

Operators:
- @ .. basic pipe: Ok(x) @ fnc1 @ fnc2 ...
- % .. filter (turns Oks into Errs) : Ok(x) % filter @ ... % ...
- | .. increases dimension : Ok(x) | Ok(y) | Ok(z) is 3-d MultiResult
- > .. reducee multivariate result via multivariate function: Ok(x)|Ok(y) > fnc
- >= .. async pipes, both uni- and multi- var (not filters)