### PR TITLE
Add typeguards for pyright

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
-from warnings import warn
 from typing import (
     Any,
     Awaitable,
@@ -16,6 +15,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from warnings import warn
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeAlias, TypeGuard
@@ -54,6 +54,9 @@ class Ok(Generic[T]):
 
     def __hash__(self) -> int:
         return hash((True, self._value))
+
+    def __bool__(self) -> Literal[True]:
+        return True
 
     def is_ok(self) -> Literal[True]:
         return True
@@ -201,6 +204,9 @@ class Err(Generic[E]):
 
     def __hash__(self) -> int:
         return hash((False, self._value))
+
+    def __bool__(self) -> Literal[False]:
+        return False
 
     def is_ok(self) -> Literal[False]:
         return False

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -11,12 +11,14 @@ def test_ok_factories() -> None:
     instance = Ok(1)
     assert instance._value == 1
     assert instance.is_ok() is True
+    assert bool(instance) is True
 
 
 def test_err_factories() -> None:
     instance = Err(2)
     assert instance._value == 2
     assert instance.is_err() is True
+    assert bool(instance) is False
 
 
 def test_eq() -> None:

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -91,5 +91,9 @@
     err = Err("error")
     if is_ok(result):
         reveal_type(result)  # N: Revealed type is "result.result.Ok[builtins.int]"
-    elif is_err(err):
+    if result:
+        reveal_type(result)  # N: Revealed type is "result.result.Ok[builtins.int]"
+    if is_err(err):
+        reveal_type(err)  # N: Revealed type is "result.result.Err[builtins.str]"
+    if not err:
         reveal_type(err)  # N: Revealed type is "result.result.Err[builtins.str]"


### PR DESCRIPTION
Pyright can't handle instance methods .is_ok/.is_err as typeguard, but `__bool__` can help him.