### PR TITLE
and_then_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ## [Unreleased]
 
 - `[added]` `is_ok` and `is_err` type guard functions as alternatives to `isinstance` checks (#69)
+- `[added]` New variant of and_then combinator for async functions (#148)
 
 ## [0.13.1] - 2023-07-19
 

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -172,6 +172,15 @@ class Ok(Generic[T]):
         """
         return op(self._value)
 
+    async def and_then_async(
+            self,
+            op: Callable[[T], Awaitable[Result[U, E]]]) -> Result[U, E]:
+        """
+        The contained result is `Ok`, so return the result of `op` with the
+        original value passed in
+        """
+        return await op(self._value)
+
     def or_else(self, op: object) -> Ok[T]:
         """
         The contained result is `Ok`, so return `Ok` with the original value
@@ -324,6 +333,12 @@ class Err(Generic[E]):
         return Err(op(self._value))
 
     def and_then(self, op: object) -> Err[E]:
+        """
+        The contained result is `Err`, so return `Err` with the original value
+        """
+        return self
+
+    async def and_then_async(self, op: object) -> Err[E]:
         """
         The contained result is `Err`, so return `Err` with the original value
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -213,6 +213,18 @@ def test_and_then() -> None:
     assert Err(3).and_then(sq_lambda).and_then(sq_lambda).err() == 3
 
 
+@pytest.mark.asyncio
+async def test_and_then_async() -> None:
+    assert (await (await Ok(2).and_then_async(sq_async)).and_then_async(sq_async)).ok() == 16
+    assert (await (await Ok(2).and_then_async(sq_async)).and_then_async(to_err_async)).err() == 4
+    assert (
+        await (await Ok(2).and_then_async(to_err_async)).and_then_async(to_err_async)
+    ).err() == 2
+    assert (
+        await (await Err(3).and_then_async(sq_async)).and_then_async(sq_async)
+    ).err() == 3
+
+
 def test_or_else() -> None:
     assert Ok(2).or_else(sq).or_else(sq).ok() == 2
     assert Ok(2).or_else(to_err).or_else(sq).ok() == 2
@@ -348,7 +360,15 @@ def sq(i: int) -> Result[int, int]:
     return Ok(i * i)
 
 
+async def sq_async(i: int) -> Result[int, int]:
+    return Ok(i * i)
+
+
 def to_err(i: int) -> Result[int, int]:
+    return Err(i)
+
+
+async def to_err_async(i: int) -> Result[int, int]:
     return Err(i)
 
 


### PR DESCRIPTION
Add async version of and_then combinator.

Tested with named functions only because AFAIK async lambdas don't exist.