### PR TITLE
[Issue #149] add generator-based do notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/
 .mypy_cache/
 venv/
 /.tox/
+.vscode
+pyrightconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Possible log types:
 
 - `[added]` `is_ok` and `is_err` type guard functions as alternatives to `isinstance` checks (#69)
 - `[added]` Add `and_then_async` for async functions (#148)
+- `[added]` Support do notation (#149)
+
 
 ## [0.13.1] - 2023-07-19
 

--- a/README.rst
+++ b/README.rst
@@ -340,6 +340,61 @@ unconventional syntax (without the usual ``@``):
     if isinstance(res, Ok):
         print(res.value)
 
+
+Do notation: syntactic sugar for a sequence of ``and_then()`` calls.
+Much like the equivalent in Rust or Haskell, but with different syntax.
+Instead of ``x <- Ok(1)`` we write ``for x in Ok(1)``.
+Since the syntax is generator-based, the final result must be the first line,
+not the last.
+
+.. sourcecode:: python
+
+
+    >>> final_result: Result[float, int] = do(
+            Ok(len(x) + int(y) + 0.5)
+            for x in Ok("hello")
+            for y in Ok(True)
+        )
+
+NOTE: If you exclude the type annotation e.g. ``Result[float, int]``
+your type checker might be unable to infer the return type.
+To avoid an error, you might need to help it with the type hint.
+
+This is similar to Rust's  `m! macro <https://docs.rs/do-notation/latest/do_notation/>`_:
+
+.. sourcecode:: rust
+
+    use do_notation::m;
+    let r = m! {
+        x <- Some("Hello, world!");
+        y <- Some(3);
+        Some(x.len() * y)
+    };
+
+
+You can also ``await`` Awaitables like async function calls. See example:
+
+.. sourcecode:: python
+
+    async def process_data(data) -> Result[float, int]:
+        out: Result[float, int] = do(
+            Ok(len(x) + int(y) + 0.5)
+            for x in await get_result_1(data)
+            for y in await get_result_2(data)
+        )
+        return out
+
+
+Development
+===========
+
+* Set up: ``pip install -e .``
+
+* Test your changes: ``flake8 src tests; mypy; pytest``
+
+* Remember to test in Python 3.8 - 3.11.
+
+
 FAQ
 ===
 

--- a/src/result/__init__.py
+++ b/src/result/__init__.py
@@ -8,6 +8,7 @@ from .result import (
     as_result,
     is_ok,
     is_err,
+    do,
 )
 
 __all__ = [
@@ -20,5 +21,6 @@ __all__ = [
     "as_result",
     "is_ok",
     "is_err",
+    "do",
 ]
 __version__ = "0.15.0.dev0"

--- a/tests/test_result_do.py
+++ b/tests/test_result_do.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+
+import pytest
+
+from result import Err, Ok, Result, do
+
+
+def test_result_do_general() -> None:
+    def resx(is_suc: bool) -> Result[str, int]:
+        return Ok("hello") if is_suc else Err(1)
+
+    def resy(is_suc: bool) -> Result[bool, int]:
+        return Ok(True) if is_suc else Err(2)
+
+    def _get_output(is_suc1: bool, is_suc2: bool) -> Result[float, int]:
+        out: Result[float, int] = do(
+            Ok(len(x) + int(y) + 0.5) for x in resx(is_suc1) for y in resy(is_suc2)
+        )
+        return out
+
+    assert _get_output(True, True) == Ok(6.5)
+    assert _get_output(True, False) == Err(2)
+    assert _get_output(False, True) == Err(1)
+    assert _get_output(False, False) == Err(1)
+
+
+@pytest.mark.asyncio
+async def test_result_do_general_async() -> None:
+    async def get_resx(is_suc: bool) -> Result[str, int]:
+        return Ok("hello") if is_suc else Err(1)
+
+    async def get_resy(is_suc: bool) -> Result[bool, int]:
+        return Ok(True) if is_suc else Err(2)
+
+    async def _get_output(is_suc1: bool, is_suc2: bool) -> Result[float, int]:
+        resx, resy = await get_resx(is_suc1), await get_resy(is_suc2)
+        out: Result[float, int] = do(
+            Ok(len(x) + int(y) + 0.5)
+            for x in resx
+            for y in resy
+        )
+        return out
+
+    assert await _get_output(True, True) == Ok(6.5)
+    assert await _get_output(True, False) == Err(2)
+    assert await _get_output(False, True) == Err(1)
+    assert await _get_output(False, False) == Err(1)


### PR DESCRIPTION
Proposal for implementaiton using generators to simulate <- notation as in Rust (or Haskell).
