### PR TITLE
Check all pydoc strings, fix problem with invalid rendered markdown

### DIFF
--- a/docs/result.md
+++ b/docs/result.md
@@ -57,20 +57,18 @@ A typeguard to check if a result is an Ok
 
 Usage: 
 
-```python
-
+``` python
 r: Result[int, str] = get_a_result()
 if is_ok(r):
      r   # r is of type Ok[int]
 elif is_err(r):
      r   # r is of type Err[str]
-
 ``` 
 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L523"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L521"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_err`
 
@@ -82,20 +80,18 @@ A typeguard to check if a result is an Err
 
 Usage: 
 
-```python
-
+``` python
 r: Result[int, str] = get_a_result()
 if is_ok(r):
      r   # r is of type Ok[int]
 elif is_err(r):
      r   # r is of type Err[str]
-
 ``` 
 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L542"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L538"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do`
 
@@ -110,7 +106,6 @@ Do notation for Result (syntactic sugar for sequence of `and_then()` calls).
 Usage: 
 
 ``` rust
-
 // This is similar to
 use do_notation::m;
 let final_result = m! {
@@ -118,17 +113,14 @@ let final_result = m! {
      y <- Ok(True);
      Ok(len(x) + int(y) + 0.5)
 };
-
 ``` 
 
 ``` rust
-
 final_result: Result[float, int] = do(
          Ok(len(x) + int(y) + 0.5)
          for x in Ok("hello")
          for y in Ok(True)
      )
-
 ``` 
 
 NOTE: If you exclude the type annotation e.g. `Result[float, int]` your type checker might be unable to infer the return type. To avoid an error, you might need to help it with the type hint. 
@@ -136,7 +128,7 @@ NOTE: If you exclude the type annotation e.g. `Result[float, int]` your type che
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L591"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L583"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do_async`
 
@@ -146,47 +138,46 @@ do_async(
 ) → Result[T, E]
 ```
 
-Async version of do. Example: ```
-``` python 
+Async version of do. Example: 
 
-final_result: Result[float, int] = await do_async(  Ok(len(x) + int(y) + z)  for x in await get_async_result_1()  for y in await get_async_result_2()  for z in get_sync_result_3()  ) 
-
-```
-
-NOTE: Python makes generators async in a counter-intuitive way.
-
-``` python 
-
-# This is a regular generator:  async def foo(): ...  do(Ok(1) for x in await foo()) 
-
-```
-
-``` python 
-
-# But this is an async generator:  async def foo(): ...  async def bar(): ...  do(  Ok(1)  for x in await foo()  for y in await bar()  ) 
-
-```
-
-We let users try to use regular `do()`, which works in some cases
-of awaiting async values. If we hit a case like above, we raise
-an exception telling the user to use `do_async()` instead.
-See `do()`.
-
-However, for better usability, it's better for `do_async()` to also accept
-regular generators, as you get in the first case:
-
-``` python 
-
-async def foo(): ...  do(Ok(1) for x in await foo()) 
-
-```
-
-Furthermore, neither mypy nor pyright can infer that the second case is
-actually an async generator, so we cannot annotate `do_async()`
-as accepting only an async generator. This is additional motivation
-to accept either.
-
+``` python
+final_result: Result[float, int] = await do_async(
+     Ok(len(x) + int(y) + z)
+         for x in await get_async_result_1()
+         for y in await get_async_result_2()
+         for z in get_sync_result_3()
+     )
 ``` 
+
+NOTE: Python makes generators async in a counter-intuitive way. 
+
+``` python
+# This is a regular generator:
+     async def foo(): ...
+     do(Ok(1) for x in await foo())
+``` 
+
+``` python
+# But this is an async generator:
+     async def foo(): ...
+     async def bar(): ...
+     do(
+         Ok(1)
+         for x in await foo()
+         for y in await bar()
+     )
+``` 
+
+We let users try to use regular `do()`, which works in some cases of awaiting async values. If we hit a case like above, we raise an exception telling the user to use `do_async()` instead. See `do()`. 
+
+However, for better usability, it's better for `do_async()` to also accept regular generators, as you get in the first case: 
+
+``` python
+async def foo(): ...
+     do(Ok(1) for x in await foo())
+``` 
+
+Furthermore, neither mypy nor pyright can infer that the second case is actually an async generator, so we cannot annotate `do_async()` as accepting only an async generator. This is additional motivation to accept either. 
 
 
 ---

--- a/docs/result.md
+++ b/docs/result.md
@@ -55,15 +55,22 @@ is_ok(result: 'Result[T, E]') → TypeGuard[Ok[T]]
 
 A typeguard to check if a result is an Ok 
 
-Usage: ``` r: Result[int, str] = get_a_result()```
-``` if is_ok(r):``` ```     r   # r is of type Ok[int]```
-``` elif is_err(r):``` ```     r   # r is of type Err[str]```
+Usage: 
 
+```python
+
+r: Result[int, str] = get_a_result()
+if is_ok(r):
+     r   # r is of type Ok[int]
+elif is_err(r):
+     r   # r is of type Err[str]
+
+``` 
 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L517"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L523"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_err`
 
@@ -73,15 +80,22 @@ is_err(result: 'Result[T, E]') → TypeGuard[Err[E]]
 
 A typeguard to check if a result is an Err 
 
-Usage: ``` r: Result[int, str] = get_a_result()```
-``` if is_ok(r):``` ```     r   # r is of type Ok[int]```
-``` elif is_err(r):``` ```     r   # r is of type Err[str]```
+Usage: 
 
+```python
+
+r: Result[int, str] = get_a_result()
+if is_ok(r):
+     r   # r is of type Ok[int]
+elif is_err(r):
+     r   # r is of type Err[str]
+
+``` 
 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L530"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L542"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do`
 
@@ -93,7 +107,11 @@ Do notation for Result (syntactic sugar for sequence of `and_then()` calls).
 
 
 
-Usage: ``` # This is similar to```
+Usage: 
+
+``` rust
+
+// This is similar to
 use do_notation::m;
 let final_result = m! {
      x <- Ok("hello");
@@ -101,14 +119,24 @@ let final_result = m! {
      Ok(len(x) + int(y) + 0.5)
 };
 
-``` final_result: Result[float, int] = do(```  Ok(len(x) + int(y) + 0.5)  for x in Ok("hello")  for y in Ok(True)  ) 
+``` 
+
+``` rust
+
+final_result: Result[float, int] = do(
+         Ok(len(x) + int(y) + 0.5)
+         for x in Ok("hello")
+         for y in Ok(True)
+     )
+
+``` 
 
 NOTE: If you exclude the type annotation e.g. `Result[float, int]` your type checker might be unable to infer the return type. To avoid an error, you might need to help it with the type hint. 
 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L570"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/master/src/result/result.py#L591"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do_async`
 
@@ -118,28 +146,26 @@ do_async(
 ) → Result[T, E]
 ```
 
-Async version of do. Example: 
+Async version of do. Example: ```
+``` python 
 
-``` final_result: Result[float, int] = await do_async(```
-     Ok(len(x) + int(y) + z)
-         for x in await get_async_result_1()
-         for y in await get_async_result_2()
-         for z in get_sync_result_3()
-     )
+final_result: Result[float, int] = await do_async(  Ok(len(x) + int(y) + z)  for x in await get_async_result_1()  for y in await get_async_result_2()  for z in get_sync_result_3()  ) 
+
+```
 
 NOTE: Python makes generators async in a counter-intuitive way.
-This is a regular generator:
-     async def foo(): ...
-     do(Ok(1) for x in await foo())
 
-But this is an async generator:
-     async def foo(): ...
-     async def bar(): ...
-     do(
-         Ok(1)
-         for x in await foo()
-         for y in await bar()
-     )
+``` python 
+
+# This is a regular generator:  async def foo(): ...  do(Ok(1) for x in await foo()) 
+
+```
+
+``` python 
+
+# But this is an async generator:  async def foo(): ...  async def bar(): ...  do(  Ok(1)  for x in await foo()  for y in await bar()  ) 
+
+```
 
 We let users try to use regular `do()`, which works in some cases
 of awaiting async values. If we hit a case like above, we raise
@@ -149,14 +175,18 @@ See `do()`.
 However, for better usability, it's better for `do_async()` to also accept
 regular generators, as you get in the first case:
 
-async def foo(): ...
-     do(Ok(1) for x in await foo())
+``` python 
+
+async def foo(): ...  do(Ok(1) for x in await foo()) 
+
+```
 
 Furthermore, neither mypy nor pyright can infer that the second case is
 actually an async generator, so we cannot annotate `do_async()`
 as accepting only an async generator. This is additional motivation
 to accept either.
 
+``` 
 
 
 ---

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -503,13 +503,19 @@ def as_async_result(
 
 def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
     """A typeguard to check if a result is an Ok
-
+    
     Usage:
-    >>> r: Result[int, str] = get_a_result()
-    >>> if is_ok(r):
-    >>>     r   # r is of type Ok[int]
-    >>> elif is_err(r):
-    >>>     r   # r is of type Err[str]
+
+    ```python
+
+    r: Result[int, str] = get_a_result()
+    if is_ok(r):
+        r   # r is of type Ok[int]
+    elif is_err(r):
+        r   # r is of type Err[str]
+    
+    ```
+    
     """
     return result.is_ok()
 
@@ -518,11 +524,17 @@ def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
     """A typeguard to check if a result is an Err
 
     Usage:
-    >>> r: Result[int, str] = get_a_result()
-    >>> if is_ok(r):
-    >>>     r   # r is of type Ok[int]
-    >>> elif is_err(r):
-    >>>     r   # r is of type Err[str]
+
+    ```python 
+
+    r: Result[int, str] = get_a_result()
+    if is_ok(r):
+        r   # r is of type Ok[int]
+    elif is_err(r):
+        r   # r is of type Err[str]
+    
+    ```
+
     """
     return result.is_err()
 
@@ -532,7 +544,10 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
 
 
     Usage:
-    >>> # This is similar to
+    
+    ``` rust
+
+    // This is similar to
     use do_notation::m;
     let final_result = m! {
         x <- Ok("hello");
@@ -540,11 +555,17 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
         Ok(len(x) + int(y) + 0.5)
     };
 
-    >>> final_result: Result[float, int] = do(
+    ```
+
+    ``` rust
+
+    final_result: Result[float, int] = do(
             Ok(len(x) + int(y) + 0.5)
             for x in Ok("hello")
             for y in Ok(True)
         )
+
+    ```
 
     NOTE: If you exclude the type annotation e.g. `Result[float, int]`
     your type checker might be unable to infer the return type.
@@ -572,19 +593,30 @@ async def do_async(
 ) -> Result[T, E]:
     """Async version of do. Example:
 
-    >>> final_result: Result[float, int] = await do_async(
+    ``` python
+
+    final_result: Result[float, int] = await do_async(
         Ok(len(x) + int(y) + z)
             for x in await get_async_result_1()
             for y in await get_async_result_2()
             for z in get_sync_result_3()
         )
 
+    ```
+
     NOTE: Python makes generators async in a counter-intuitive way.
-    This is a regular generator:
+
+    ``` python
+
+    # This is a regular generator:
         async def foo(): ...
         do(Ok(1) for x in await foo())
 
-    But this is an async generator:
+    ```
+
+    ``` python
+
+    # But this is an async generator:
         async def foo(): ...
         async def bar(): ...
         do(
@@ -592,6 +624,8 @@ async def do_async(
             for x in await foo()
             for y in await bar()
         )
+
+    ```
 
     We let users try to use regular `do()`, which works in some cases
     of awaiting async values. If we hit a case like above, we raise
@@ -601,8 +635,12 @@ async def do_async(
     However, for better usability, it's better for `do_async()` to also accept
     regular generators, as you get in the first case:
 
+    ``` python
+
     async def foo(): ...
         do(Ok(1) for x in await foo())
+
+    ```
 
     Furthermore, neither mypy nor pyright can infer that the second case is
     actually an async generator, so we cannot annotate `do_async()`

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -503,7 +503,7 @@ def as_async_result(
 
 def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
     """A typeguard to check if a result is an Ok
-    
+
     Usage:
 
     ```python
@@ -513,9 +513,9 @@ def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
         r   # r is of type Ok[int]
     elif is_err(r):
         r   # r is of type Err[str]
-    
+
     ```
-    
+
     """
     return result.is_ok()
 
@@ -525,14 +525,14 @@ def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
 
     Usage:
 
-    ```python 
+    ```python
 
     r: Result[int, str] = get_a_result()
     if is_ok(r):
         r   # r is of type Ok[int]
     elif is_err(r):
         r   # r is of type Err[str]
-    
+
     ```
 
     """
@@ -544,7 +544,7 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
 
 
     Usage:
-    
+
     ``` rust
 
     // This is similar to

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -506,14 +506,12 @@ def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
 
     Usage:
 
-    ```python
-
+    ``` python
     r: Result[int, str] = get_a_result()
     if is_ok(r):
         r   # r is of type Ok[int]
     elif is_err(r):
         r   # r is of type Err[str]
-
     ```
 
     """
@@ -525,14 +523,12 @@ def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
 
     Usage:
 
-    ```python
-
+    ``` python
     r: Result[int, str] = get_a_result()
     if is_ok(r):
         r   # r is of type Ok[int]
     elif is_err(r):
         r   # r is of type Err[str]
-
     ```
 
     """
@@ -546,7 +542,6 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
     Usage:
 
     ``` rust
-
     // This is similar to
     use do_notation::m;
     let final_result = m! {
@@ -554,17 +549,14 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
         y <- Ok(True);
         Ok(len(x) + int(y) + 0.5)
     };
-
     ```
 
     ``` rust
-
     final_result: Result[float, int] = do(
             Ok(len(x) + int(y) + 0.5)
             for x in Ok("hello")
             for y in Ok(True)
         )
-
     ```
 
     NOTE: If you exclude the type annotation e.g. `Result[float, int]`
@@ -594,28 +586,23 @@ async def do_async(
     """Async version of do. Example:
 
     ``` python
-
     final_result: Result[float, int] = await do_async(
         Ok(len(x) + int(y) + z)
             for x in await get_async_result_1()
             for y in await get_async_result_2()
             for z in get_sync_result_3()
         )
-
     ```
 
     NOTE: Python makes generators async in a counter-intuitive way.
 
     ``` python
-
     # This is a regular generator:
         async def foo(): ...
         do(Ok(1) for x in await foo())
-
     ```
 
     ``` python
-
     # But this is an async generator:
         async def foo(): ...
         async def bar(): ...
@@ -624,7 +611,6 @@ async def do_async(
             for x in await foo()
             for y in await bar()
         )
-
     ```
 
     We let users try to use regular `do()`, which works in some cases
@@ -636,10 +622,8 @@ async def do_async(
     regular generators, as you get in the first case:
 
     ``` python
-
     async def foo(): ...
         do(Ok(1) for x in await foo())
-
     ```
 
     Furthermore, neither mypy nor pyright can infer that the second case is


### PR DESCRIPTION
Fix issue: #169 

I think the best option is to use a little bit of markdown, but if u want to use pure pydoc strings, I can easily swap to ">>>" with keeping all the newlines.

Also sorry for not rendering docs, I don't use python often so I dunno how to make module usable in command line, and I don't wanna break your docs while using lazydocs API

Waiting for your respond
GNUSheep