### PR TITLE
fix: PyPI not showing description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,8 @@
 name = result
 version = attr: result.__version__
 description = A Rust-like result type for Python
-long_description = file: README.rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = rust, result, enum
 author = Danilo Bargen
 author_email = mail@dbrgn.ch


### PR DESCRIPTION
Closes #171

See https://pypi.org/help/#description-content-type