### PR TITLE
Introducing branching operator

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -247,15 +247,16 @@ class Err(Generic[E]):
         return "Err({})".format(repr(self._value))
 
     def __eq__(self, other: Any) -> bool:
+        """
+        Due to the nature of exception comparison, errors containing 
+        exception would not compare, e.g:
+        Err(ValueError("")) != Err(ValueError(""))
+        The extra code will handle exception comparison
+        """
         if isinstance(other, Err):
             other_err = cast(Err, other)
             self_is_xcpt = isinstance(self._value, BaseException)
             other_is_xcpt = isinstance(other_err._value, BaseException)
-            """
-            Due to the nature of exception comparison, errors containing 
-            exception would not compare, e.g:
-            Err(ValueError("")) != Err(ValueError(""))
-            """
             if self_is_xcpt and other_is_xcpt:
                 return (
                     type(self._value) is type(other_err._value)
@@ -313,6 +314,11 @@ class Err(Generic[E]):
     
     @property
     def branch(self) -> NoReturn:
+        """
+        Branching operator raises a special excpetion on the error path.
+        This exception will then be caugh by @branching decorator for the
+        error to be passed by value to the caller.
+        """
         raise _BranchOperatorShortCircuit[E](self)
 
     def expect(self, message: str) -> NoReturn:

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+
+import pytest
+
+from result import Err, Ok, Result, branching
+
+
+@pytest.mark.parametrize(
+    "x, y, expectation",
+    [
+        (Ok(1), Ok(2), Ok(3)),
+        (Ok(1), Err("erm.."), Err("erm..")),
+        (Ok("erm"), Ok("mm..."), Ok("ermmm...")),
+    ],
+)
+def test_branching(x, y, expectation):
+    def foo() -> Result[int, str]:
+        return x
+
+    def bar() -> Result[int, str]:
+        return y
+
+    @branching
+    def sum() -> Result[int, str]:
+        return Ok(foo().branch + bar().branch)
+
+    assert sum() == expectation
+
+
+def test_returning_result_vs_branching_equivalency():
+    def _ok() -> Result[int, str]:
+        return Ok(69)
+
+    def _err() -> Result[int, str]:
+        return Err(420)
+
+    @branching
+    def _ok_branching() -> Result[int, str]:
+        def inner() -> Result[int, str]:
+            return Ok(69)
+
+        return Ok(inner().branch)
+
+    @branching
+    def _err_branching() -> Result[int, str]:
+        def inner() -> Result[int, str]:
+            return Err(420)
+
+        return Ok(inner().branch)
+
+    assert _ok() == _ok_branching()
+    assert _err() == _err_branching()

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -28,6 +28,9 @@ def test_eq() -> None:
     assert not (Ok(1) != Ok(1))
     assert Ok(1) != "abc"
     assert Ok("0") != Ok(0)
+    assert Err(ValueError("invalid value")) == Err(ValueError("invalid value"))
+    assert Err(ValueError("abc")) != Err(ValueError("def"))
+    assert Err(ValueError()) != Err(IndexError())
 
 
 def test_hash() -> None:


### PR DESCRIPTION
Hi, please take a look at my shot at implementing the `branch`/`try!`/`?` operator.
In this approach i've implemented it via `branch` property, which propagates the types correctly and is chainable, e.g
`val: float = get_cmd_line().branch.parse_float().branch`

the only inconvenience is that functions need to be decorated with `@branching` in order to turn the auxiliary exception on the error path and return it by value to the calling code

I've also fixed `__eq__` on the `Err` to handle exception comparison - it's very useful in conjunction with `@as_result` that tends to return `Err[std exception]`