### PR TITLE
adapt `as_result` and `as_async_result` so they can accept generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Possible log types:
 
 ## [Unreleased]
 
+- `[changed]` changed `as_result` so it can work with both generators and functions
+- `[changed]` changed `as_async_result` so it can work with both async generators and async functions
+
 ## [0.16.1] - 2024-02-29
 
 - `[fixed]` PyPI not showing description (#176)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -306,6 +306,38 @@ def test_as_result() -> None:
     assert isinstance(bad_result.unwrap_err(), ValueError)
 
 
+def test_as_result_with_generator() -> None:
+    """
+    ``as_result()`` works with generators.
+    """
+
+    @as_result(ValueError)
+    def random_generator():
+        yield 1
+        yield 2
+        yield 3
+
+    for i in random_generator():
+        assert i in (Ok(1), Ok(2), Ok(3))
+
+
+def test_as_result_with_generator_and_exception() -> None:
+    """
+    ``as_result()`` works with generators that raise exceptions.
+    """
+
+    @as_result(ValueError)
+    def random_generator():
+        yield 1
+        yield 2
+        raise ValueError
+
+    result = [i for i in random_generator()]
+    assert result[:2] == [Ok(1), Ok(2)]
+    assert result[-1].is_err()
+    assert isinstance(result[-1].unwrap_err(), ValueError)
+
+
 def test_as_result_other_exception() -> None:
     """
     ``as_result()`` only catches the specified exceptions.
@@ -373,6 +405,40 @@ async def test_as_async_result() -> None:
     assert good_result.unwrap() == 123
     assert isinstance(bad_result, Err)
     assert isinstance(bad_result.unwrap_err(), ValueError)
+
+
+@pytest.mark.asyncio
+async def test_as_async_result_with_generator() -> None:
+    """
+    ``as_result()`` works with async generators.
+    """
+
+    @as_async_result(ValueError)
+    async def random_generator():
+        yield 1
+        yield 2
+        yield 3
+
+    async for i in random_generator():
+        assert i in (Ok(1), Ok(2), Ok(3))
+
+
+@pytest.mark.asyncio
+async def test_as_async_result_with_generator_and_exception() -> None:
+    """
+    ``as_result()`` works with async generators that raise exceptions.
+    """
+
+    @as_async_result(ValueError)
+    async def random_generator():
+        yield 1
+        yield 2
+        raise ValueError
+
+    result = [i async for i in random_generator()]
+    assert result[:2] == [Ok(1), Ok(2)]
+    assert result[-1].is_err()
+    assert isinstance(result[-1].unwrap_err(), ValueError)
 
 
 def sq(i: int) -> Result[int, int]:


### PR DESCRIPTION
Hello!

I'm seeking an alternative solution for a specific use case involving async generators. Our work heavily relies on async generators, and I needed a way to decorate an async generator with `as_async_result` to yield a `Result` for every yielded object. To make this functionality broadly applicable, I extended it to work with normal generators as well.

Here's an example:
```python
import asyncio
from typing import AsyncGenerator

from result import Ok, as_async_result

@as_async_result(Exception)
async def random_generator() -> AsyncGenerator[int, None]:
    await asyncio.sleep(1)
    yield 1
    yield 2

async def normal_run():
    async for i in random_generator():
        assert isinstance(i, Ok)

@as_async_result(Exception)
async def error_generator() -> AsyncGenerator[Exception, None]:
    await asyncio.sleep(1)
    yield 1
    yield Exception('Error')

async def error_run():
    result = [i async for i in error_generator()]
    assert isinstance(result[0], Ok)
    assert isinstance(result[1], Exception)
    # here we can unwrap and in case of error reraise error so we can proceed to upstream or do any logic

if __name__ == '__main__':
    asyncio.run(normal_run())
```

For context, in our real-world scenario, we create a MongoDB Async Cursor to fetch documents asynchronously and yield them. Using this approach, if an error occurs during fetching, such as a connection error, we can safely stop the process and propagate the error upstream.

What do you think?