### PR TITLE
feat: add overload to unwrap_or_raise to raise the exception itself

### DIFF
--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -157,6 +157,10 @@ def test_unwrap_or_raise() -> None:
         n.unwrap_or_raise(ValueError)
     assert exc_info.value.args == ('nay',)
 
+    n2 = Err(ValueError('nay'))
+    with pytest.raises(ValueError) as exc_info:
+        n2.unwrap_or_raise()
+
 
 def test_map() -> None:
     o = Ok('yay')


### PR DESCRIPTION
add overload to unwrap_or_raise to raise the exception itself
```python
   n2 = Err(ValueError('nay'))
   with pytest.raises(ValueError) as exc_info:
        n2.unwrap_or_raise()
```