### PR TITLE
Replace TypeGuard with TypeIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Possible log types:
 
 ## [Unreleased]
 
+- `[changed]` Improve type narrowing for `is_ok` and `is_err` type guards by
+  replacing `typing.TypeGuard` with `typing.TypeIs` (#193)
+
 ## [0.17.0] - 2024-06-02
 
 - `[added]` Add `inspect()` and `inspect_err()` methods (#185)

--- a/README.md
+++ b/README.md
@@ -156,27 +156,6 @@ False
 True
 ```
 
-The benefit of `isinstance` is better type checking that type guards currently
-do not offer,
-
-```python
-res1: Result[int, str] = some_result()
-if isinstance(res1, Err):
-    print("Error...:", res1.err_value) # res1 is narrowed to an Err
-    return
-res1.ok()
-
-res2: Result[int, str] = some_result()
-if res1.is_err():
-    print("Error...:", res2.err_value) # res1 is NOT narrowed to an Err here
-    return
-res1.ok()
-```
-
-There is a proposed [PEP 724 – Stricter Type Guards](https://peps.python.org/pep-0724/)
-which may allow the `is_ok` and `is_err` type guards to work as expected in
-future versions of Python.
-
 Convert a `Result` to the value or `None`:
 
 ``` python

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ def get_user_by_email(email: str) -> Result[User, str]:
     return Ok(user)
 
 user_result = get_user_by_email(email)
-if isinstance(user_result, Ok): # or `is_ok(user_result)`
+if is_ok(user_result): # or `isinstance(user_result, Ok)`
     # type(user_result.ok_value) == User
     do_something(user_result.ok_value)
-else: # or `elif is_err(user_result)`
+else:
     # type(user_result.err_value) == str
     raise RuntimeError('Could not fetch user: %s' % user_result.err_value)
 ```
@@ -97,12 +97,9 @@ for a, b in values:
 
 Not all methods
 (<https://doc.rust-lang.org/std/result/enum.Result.html>) have been
-implemented, only the ones that make sense in the Python context. By
-using `isinstance` to check for `Ok` or `Err` you get type safe access
-to the contained value when using [MyPy](https://mypy.readthedocs.io/)
-to typecheck your code. All of this in a package allowing easier
-handling of values that can be OK or not, without resorting to custom
-exceptions.
+implemented, only the ones that make sense in the Python context.
+All of this in a package allowing easier handling of values that can
+be OK or not, without resorting to custom exceptions.
 
 ## API
 
@@ -119,19 +116,18 @@ Creating an instance:
 
 Checking whether a result is `Ok` or `Err`. You can either use `is_ok`
 and `is_err` type guard **functions** or `isinstance`. This way you get
-type safe access that can be checked with MyPy. The `is_ok()` or
-`is_err()` **methods** can be used if you don't need the type safety
-with MyPy:
+type safe access that can be checked with MyPy (compared to the `is_ok`
+and `is_err` **methods**).
 
 ``` python
 >>> res = Ok('yay')
->>> isinstance(res, Ok)
-True
 >>> is_ok(res)
 True
->>> isinstance(res, Err)
-False
+>>> isinstance(res, Ok)
+True
 >>> is_err(res)
+False
+>>> isinstance(res, Err)
 False
 >>> res.is_ok()
 True

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@
 - [`result.as_result`](./result.md#function-as_result): Make a decorator to turn a function into one that returns a ``Result``.
 - [`result.do`](./result.md#function-do): Do notation for Result (syntactic sugar for sequence of `and_then()` calls).
 - [`result.do_async`](./result.md#function-do_async): Async version of do. Example:
-- [`result.is_err`](./result.md#function-is_err): A typeguard to check if a result is an Err
-- [`result.is_ok`](./result.md#function-is_ok): A typeguard to check if a result is an Ok
+- [`result.is_err`](./result.md#function-is_err): A type guard to check if a result is an Err
+- [`result.is_ok`](./result.md#function-is_ok): A type guard to check if a result is an Ok
 
 
 ---

--- a/docs/result.md
+++ b/docs/result.md
@@ -13,7 +13,7 @@
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L465"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L467"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `as_result`
 
@@ -30,7 +30,7 @@ Regular return values are turned into ``Ok(return_value)``. Raised exceptions of
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L497"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L499"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `as_async_result`
 
@@ -45,15 +45,15 @@ Make a decorator to turn an async function into one that returns a ``Result``. R
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L530"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L532"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_ok`
 
 ```python
-is_ok(result: 'Result[T, E]') → TypeGuard[Ok[T]]
+is_ok(result: 'Result[T, E]') → TypeIs[Ok[T]]
 ```
 
-A typeguard to check if a result is an Ok 
+A type guard to check if a result is an Ok 
 
 Usage: 
 
@@ -68,15 +68,15 @@ elif is_err(r):
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L547"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L549"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_err`
 
 ```python
-is_err(result: 'Result[T, E]') → TypeGuard[Err[E]]
+is_err(result: 'Result[T, E]') → TypeIs[Err[E]]
 ```
 
-A typeguard to check if a result is an Err 
+A type guard to check if a result is an Err 
 
 Usage: 
 
@@ -91,7 +91,7 @@ elif is_err(r):
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L564"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L566"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do`
 
@@ -128,7 +128,7 @@ NOTE: If you exclude the type annotation e.g. `Result[float, int]` your type che
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L609"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L611"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `do_async`
 
@@ -182,12 +182,12 @@ Furthermore, neither mypy nor pyright can infer that the second case is actually
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `Ok`
 A value that indicates success and which stores arbitrary data for the return value. 
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -218,7 +218,7 @@ Return the inner value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L185"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `and_then`
 
@@ -230,7 +230,7 @@ The contained result is `Ok`, so return the result of `op` with the original val
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `and_then_async`
 
@@ -242,7 +242,7 @@ The contained result is `Ok`, so return the result of `op` with the original val
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L76"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `err`
 
@@ -254,7 +254,7 @@ Return `None`.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `expect`
 
@@ -266,7 +266,7 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `expect_err`
 
@@ -278,31 +278,31 @@ Raise an UnwrapError since this type is `Ok`
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L207"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `inspect`
 
 ```python
-inspect(op: 'Callable[[T], None]') → Result[T, E]
+inspect(op: 'Callable[[T], Any]') → Result[T, E]
 ```
 
 Calls a function with the contained value if `Ok`. Returns the original result. 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L214"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `inspect_err`
 
 ```python
-inspect_err(op: 'Callable[[E], None]') → Result[T, E]
+inspect_err(op: 'Callable[[E], Any]') → Result[T, E]
 ```
 
 Calls a function with the contained value if `Err`. Returns the original result. 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L67"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `is_err`
 
@@ -316,7 +316,7 @@ is_err() → Literal[False]
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L66"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `is_ok`
 
@@ -330,7 +330,7 @@ is_ok() → Literal[True]
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L147"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L149"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map`
 
@@ -342,7 +342,7 @@ The contained result is `Ok`, so return `Ok` with original value mapped to a new
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L156"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_async`
 
@@ -354,7 +354,7 @@ The contained result is `Ok`, so return the result of `op` with the original val
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L177"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_err`
 
@@ -366,7 +366,7 @@ The contained result is `Ok`, so return `Ok` with the original value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_or`
 
@@ -378,7 +378,7 @@ The contained result is `Ok`, so return the original value mapped to a new value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_or_else`
 
@@ -390,7 +390,7 @@ The contained result is `Ok`, so return original value mapped to a new value usi
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `ok`
 
@@ -402,7 +402,7 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `or_else`
 
@@ -414,7 +414,7 @@ The contained result is `Ok`, so return `Ok` with the original value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap`
 
@@ -426,7 +426,7 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_err`
 
@@ -438,7 +438,7 @@ Raise an UnwrapError since this type is `Ok`
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or`
 
@@ -450,7 +450,7 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L135"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or_else`
 
@@ -462,7 +462,7 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or_raise`
 
@@ -475,12 +475,12 @@ Return the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `DoException`
 This is used to signal to `do()` that the result is an `Err`, which short-circuits the generator and returns that Err. Using this exception for control flow in `do()` allows us to simulate `and_then()` in the Err case: namely, we don't call `op`, we just return `self` (the Err). 
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L230"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -498,12 +498,12 @@ __init__(err: 'Err[E]') → None
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `Err`
 A value that signifies failure and which stores arbitrary data for the error. 
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L248"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L250"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -534,7 +534,7 @@ Return the inner value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L393"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `and_then`
 
@@ -546,7 +546,7 @@ The contained result is `Err`, so return `Err` with the original value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L397"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L399"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `and_then_async`
 
@@ -558,7 +558,7 @@ The contained result is `Err`, so return `Err` with the original value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L275"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `err`
 
@@ -570,7 +570,7 @@ Return the error.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L306"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `expect`
 
@@ -582,7 +582,7 @@ Raises an `UnwrapError`.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L316"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L318"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `expect_err`
 
@@ -594,31 +594,31 @@ Return the inner value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L410"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L412"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `inspect`
 
 ```python
-inspect(op: 'Callable[[T], None]') → Result[T, E]
+inspect(op: 'Callable[[T], Any]') → Result[T, E]
 ```
 
 Calls a function with the contained value if `Ok`. Returns the original result. 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L416"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L418"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `inspect_err`
 
 ```python
-inspect_err(op: 'Callable[[E], None]') → Result[T, E]
+inspect_err(op: 'Callable[[E], Any]') → Result[T, E]
 ```
 
 Calls a function with the contained value if `Err`. Returns the original result. 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L266"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L268"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `is_err`
 
@@ -632,7 +632,7 @@ is_err() → Literal[True]
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L265"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `is_ok`
 
@@ -646,7 +646,7 @@ is_ok() → Literal[False]
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L359"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L361"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map`
 
@@ -658,7 +658,7 @@ Return `Err` with the same value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L365"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L367"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_async`
 
@@ -670,7 +670,7 @@ The contained result is `Ok`, so return the result of `op` with the original val
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L384"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L386"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_err`
 
@@ -682,7 +682,7 @@ The contained result is `Err`, so return `Err` with original error mapped to a n
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L372"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L374"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_or`
 
@@ -694,7 +694,7 @@ Return the default value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L378"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L380"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `map_or_else`
 
@@ -706,7 +706,7 @@ Return the result of the default operation
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `ok`
 
@@ -718,7 +718,7 @@ Return `None`.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L403"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L405"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `or_else`
 
@@ -730,7 +730,7 @@ The contained result is `Err`, so return the result of `op` with the original va
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L322"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap`
 
@@ -742,7 +742,7 @@ Raises an `UnwrapError`.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L334"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L336"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_err`
 
@@ -754,7 +754,7 @@ Return the inner value
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L340"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L342"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or`
 
@@ -766,7 +766,7 @@ Return `default`.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L346"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L348"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or_else`
 
@@ -778,7 +778,7 @@ The contained result is ``Err``, so return the result of applying ``op`` to the 
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L353"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L355"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `unwrap_or_raise`
 
@@ -791,14 +791,14 @@ The contained result is ``Err``, so raise the exception with the value.
 
 ---
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L440"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L442"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `UnwrapError`
 Exception raised from ``.unwrap_<...>`` and ``.expect_<...>`` calls. 
 
 The original ``Result`` can be accessed via the ``.result`` attribute, but this is not intended for regular use, as type information is lost: ``UnwrapError`` doesn't know about both ``T`` and ``E``, since it's raised from ``Ok()`` or ``Err()`` which only knows about either ``T`` or ``E``, not both. 
 
-<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L453"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L455"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    typing_extensions;python_version<'3.10'
+    typing_extensions>=4.10.0;python_version<'3.13'
 package_dir =
     =src
 packages = find:

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -20,10 +20,12 @@ from typing import (
     Union,
 )
 
+from typing_extensions import TypeIs
+
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec, TypeAlias, TypeGuard
+    from typing import ParamSpec, TypeAlias
 else:
-    from typing_extensions import ParamSpec, TypeAlias, TypeGuard
+    from typing_extensions import ParamSpec, TypeAlias
 
 
 T = TypeVar("T", covariant=True)  # Success type
@@ -527,8 +529,8 @@ def as_async_result(
     return decorator
 
 
-def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
-    """A typeguard to check if a result is an Ok
+def is_ok(result: Result[T, E]) -> TypeIs[Ok[T]]:
+    """A type guard to check if a result is an Ok
 
     Usage:
 
@@ -544,8 +546,8 @@ def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
     return result.is_ok()
 
 
-def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
-    """A typeguard to check if a result is an Err
+def is_err(result: Result[T, E]) -> TypeIs[Err[E]]:
+    """A type guard to check if a result is an Err
 
     Usage:
 

--- a/tests/type_checking/test_result.yml
+++ b/tests/type_checking/test_result.yml
@@ -85,11 +85,16 @@
 - case: map_result
   disable_cache: false
   main: |
-    from result import Ok, Err, is_ok, is_err
+    from result import Result, Ok, Err, is_ok, is_err
 
-    result = Ok(1)
-    err = Err("error")
-    if is_ok(result):
-        reveal_type(result)  # N: Revealed type is "result.result.Ok[builtins.int]"
-    elif is_err(err):
-        reveal_type(err)  # N: Revealed type is "result.result.Err[builtins.str]"
+    res1: Result[int, str] = Ok(1)
+    if is_ok(res1):
+        reveal_type(res1)  # N: Revealed type is "result.result.Ok[builtins.int]"
+    else:
+        reveal_type(res1)  # N: Revealed type is "result.result.Err[builtins.str]"
+
+    res2: Result[int, str] = Err("error")
+    if is_err(res2):
+        reveal_type(res2)  # N: Revealed type is "result.result.Err[builtins.str]"
+    else:
+        reveal_type(res2)  # N: Revealed type is "result.result.Ok[builtins.int]"


### PR DESCRIPTION
# Use `TypeIs` instead of `TypeGuard` 

... to improve type narrowing for `is_ok` and `is_err` type guards.

Starting from Python 3.13 `TypeIs` is in the standards `typing` module. I decided to not introduce anything Python 3.13, since it should probably be handled in a seperate PR (see #181). 

See: https://github.com/rustedpy/result/issues/193