### PR TITLE
feat: add `unwrap_or_raise_itself()` if a value of `Err` is a `BaseException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Possible log types:
 - `[changed]` Improve type narrowing for `is_ok` and `is_err` type guards by
   replacing `typing.TypeGuard` with `typing.TypeIs` (#193)
 
+- `[added]` Add `unwrap_or_raise_itself()` for `Ok` and `Err` (#199)
+
 ## [0.17.0] - 2024-06-02
 
 - `[added]` Add `inspect()` and `inspect_err()` methods (#185)

--- a/docs/result.md
+++ b/docs/result.md
@@ -475,6 +475,19 @@ Return the value.
 
 ---
 
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `unwrap_or_raise_itself`
+
+```python
+unwrap_or_raise_itself() → T
+```
+
+Return the value. 
+
+
+---
+
 <a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `DoException`
@@ -787,6 +800,21 @@ unwrap_or_raise(e: 'Type[TBE]') → NoReturn
 ```
 
 The contained result is ``Err``, so raise the exception with the value. 
+
+
+---
+
+<a href="https://github.com/rustedpy/result/blob/main/src/result/result.py#L355"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `unwrap_or_raise_itself`
+
+```python
+unwrap_or_raise_itself() → NoReturn
+```
+
+The contained result is ``Err``, so raise the error itself. 
+
+If the error is not an exception, this will raise an `UnwrapError`. 
 
 
 ---

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -367,6 +367,8 @@ class Err(Generic[E]):
     def unwrap_or_raise_itself(self) -> NoReturn:
         """
         The contained result is ``Err``, so raise the error itself.
+
+        If the error is not an exception, this will raise an `UnwrapError`.
         """
         if isinstance(self._value, BaseException):
             raise self._value

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -146,6 +146,12 @@ class Ok(Generic[T]):
         """
         return self._value
 
+    def unwrap_or_raise_itself(self) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
     def map(self, op: Callable[[T], U]) -> Ok[U]:
         """
         The contained result is `Ok`, so return `Ok` with original value mapped to
@@ -357,6 +363,17 @@ class Err(Generic[E]):
         The contained result is ``Err``, so raise the exception with the value.
         """
         raise e(self._value)
+
+    def unwrap_or_raise_itself(self) -> NoReturn:
+        """
+        The contained result is ``Err``, so raise the error itself.
+        """
+        if isinstance(self._value, BaseException):
+            raise self._value
+
+        raise TypeError(
+            f"Called `Result.unwrap_or_raise_itself()` on non-exception value: {self._value}"
+        )
 
     def map(self, op: object) -> Err[E]:
         """

--- a/src/result/result.py
+++ b/src/result/result.py
@@ -371,8 +371,9 @@ class Err(Generic[E]):
         if isinstance(self._value, BaseException):
             raise self._value
 
-        raise TypeError(
-            f"Called `Result.unwrap_or_raise_itself()` on non-exception value: {self._value}"
+        raise UnwrapError(
+            self,
+            f"Called `Result.unwrap_or_raise_itself()` on non-exception value: {self._value}",
         )
 
     def map(self, op: object) -> Err[E]:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -158,6 +158,18 @@ def test_unwrap_or_raise() -> None:
     assert exc_info.value.args == ('nay',)
 
 
+def test_unwrap_or_raise_itself() -> None:
+    o = Ok('yay')
+    n = Err(RuntimeError('nay'))
+    assert o.unwrap_or_raise_itself() == 'yay'
+    with pytest.raises(RuntimeError) as exc_info:
+        n.unwrap_or_raise_itself()
+    assert exc_info.value.args == ('nay',)
+    ne = Err('nay')
+    with pytest.raises(UnwrapError):
+        ne.unwrap_or_raise_itself()
+
+
 def test_map() -> None:
     o = Ok('yay')
     n = Err('nay')


### PR DESCRIPTION
This PR enhances #192. If this is merged, Close: #192.

Rather than overriding the existing behavior of `unwrap_or_raise()`, I added a new method: `unwrap_or_raise_itself()`.

With this addition, users can better determine if an Err value is a BaseException. This option may be helpful in such cases.

The unwrap_or_raise_itself() method is now available in both Ok and Err classes.

Example:
```py
e = Err(RuntimeError("nay"))
e.unwrap_or_raise_itself()
>>> e.unwrap_or_raise_itself()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/Users/colk/Repositories/github.com/Colk-tech/result/src/result/result.py", line 374, in unwrap_or_raise_itself
    raise self._value
RuntimeError: nay
```

By the way, this is my first time creating a PR for an OSS project, so I’d be grateful for any advice you might have :)