### PR TITLE
fix: make UnwrapError pickleable via __reduce__

### DIFF
--- a/src/result/result.py
+++ b/src/result/result.py
@@ -456,6 +456,14 @@ class UnwrapError(Exception):
         self._result = result
         super().__init__(message)
 
+    def __reduce__(self) -> tuple[type[UnwrapError], tuple[Result[object, object], str]]:
+        # Exception.__reduce__ only preserves self.args, which contains just the
+        # message string.  The `_result` attribute is stored separately and is
+        # therefore lost during pickling/unpickling (e.g. across a multiprocessing
+        # boundary).  Returning both constructor arguments here ensures faithful
+        # round-trip serialisation.
+        return (type(self), (self._result, self.args[0]))
+
     @property
     def result(self) -> Result[Any, Any]:
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 from typing import Callable
 
 import pytest
@@ -300,6 +301,30 @@ def test_error_context() -> None:
         n.unwrap()
     exc = exc_info.value
     assert exc.result is n
+
+
+def test_unwrap_error_pickleable() -> None:
+    """UnwrapError must survive a pickle round-trip (e.g. across multiprocessing)."""
+    n = Err('nay')
+    with pytest.raises(UnwrapError) as exc_info:
+        n.unwrap()
+    exc = exc_info.value
+
+    restored: UnwrapError = pickle.loads(pickle.dumps(exc))
+
+    assert restored.args == exc.args
+    assert restored._result == exc._result
+    assert restored.result == exc.result
+
+    # Also check the Ok variant (expect_err raises with an Ok result)
+    o = Ok('yay')
+    with pytest.raises(UnwrapError) as exc_info2:
+        o.expect_err('must fail')
+    exc2 = exc_info2.value
+
+    restored2: UnwrapError = pickle.loads(pickle.dumps(exc2))
+    assert restored2.args == exc2.args
+    assert restored2._result == exc2._result
 
 
 def test_slots() -> None:


### PR DESCRIPTION
## What

`UnwrapError` cannot be pickled, which breaks multiprocessing use-cases
where exceptions are sent across process boundaries (e.g. with
`concurrent.futures.ProcessPoolExecutor`).

```python
>>> import pickle
>>> from result import Err, UnwrapError
>>> try:
...     Err(None).unwrap()
... except UnwrapError as e:
...     pickle.loads(pickle.dumps(e))   # TypeError!
TypeError: UnwrapError.__init__() missing 1 required positional argument: 'message'
```

## Why

Python's default `Exception` pickling only preserves `self.args`, which
for `UnwrapError` contains only the message string.  The `_result`
attribute is stored separately, so pickle cannot reconstruct the object —
it calls `UnwrapError(message)` with one argument instead of the required
two.

## Fix

Add `__reduce__` to return `(type(self), (self._result, self.args[0]))`.
Pickle will then call `UnwrapError(result, message)` on restore,
preserving the full state.

A regression test covering both `Err.unwrap()` and `Ok.expect_err()` is included.

Fixes #200.

---

This pull request was prepared with the assistance of AI, under my direction and review.